### PR TITLE
Throttle updating on browser's animation frame

### DIFF
--- a/src/components/Clamp.js
+++ b/src/components/Clamp.js
@@ -99,7 +99,7 @@ export default {
 
       if (this.autoresize) {
         let resizeCallback = () => {
-          this.update()
+          window.requestAnimationFrame(this.update)
         }
         addListener(this.$el, resizeCallback)
         this.unregisterResizeCallback = () => {


### PR DESCRIPTION
Hello.

Thanks for this component, it's working really well. Better than the one we were using before.

I've spotted a minor issue:
On Chrome 71, using autoresize prop on a clamped text, the first time I resize the browser a "ResizeObserver loop limit exceeded" Javascript error/message is issued, without any stacktrace. Then there is no message anymore. The component is still working, despite the message;

You can try it by adding 
```
window.onerror = (error) => console.log(error)
```
There is no issue on Firefox.

Throttling the updates on the browser's animation frame ensures it's updated at most at 60 FPS.