### PR TITLE
Use the first non-empty text node for getting the line count.

### DIFF
--- a/src/components/Clamp.js
+++ b/src/components/Clamp.js
@@ -127,7 +127,7 @@ export default {
       this.localExpanded = !this.localExpanded
     },
     getLines () {
-      return this.$refs.content.getClientRects().length
+      return this.$refs.text.getClientRects().length
     },
     isOverflow () {
       if (!this.maxLines && !this.maxHeight) {


### PR DESCRIPTION
As far as I can see this is needed to have a block node after the clamped text, like this:

```
<v-clamp autoresize :max-lines="1">
    {{ text }}
    <button
            v-if="expanded || clamped"
            slot="after"
            slot-scope="{ toggle, expanded, clamped }"
            class="d-block"
            @click="toggle"
    >
        {{ expanded ? 'show less' : 'show more' }}
    </button>
</v-clamp>
```