### PR TITLE
feat: add github links to package

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
   "bugs": {
     "url": "https://github.com/Justineo/vue-clamp/issues"
   },
-  "homepage": "https://github.com/Justineo/vue-clamp#readme",
+  "homepage": "https://justineo.github.io/vue-clamp/demo/",
   "main": "dist/vue-clamp.js",
   "module": "Clamp.js",
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -11,6 +11,14 @@
     "prepublishOnly": "cp ./src/components/Clamp.js .",
     "publish": "rm ./Clamp.js"
   },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/Justineo/vue-clamp.git"
+  },
+  "bugs": {
+    "url": "https://github.com/Justineo/vue-clamp/issues"
+  },
+  "homepage": "https://github.com/Justineo/vue-clamp#readme",
   "main": "dist/vue-clamp.js",
   "module": "Clamp.js",
   "dependencies": {


### PR DESCRIPTION
This is so sites like npmjs.com can link to the github repository directly rather than go to the docs site and then click on the github link