### PR TITLE
Add SSR support

### DIFF
--- a/src/components/Clamp.js
+++ b/src/components/Clamp.js
@@ -22,8 +22,9 @@ export default {
     },
     expanded: Boolean
   },
-  data () {
+  data ({$isServer}) {
     return {
+      isServer: $isServer,
       offset: null,
       text: this.getText(),
       localExpanded: !!this.expanded
@@ -205,13 +206,13 @@ export default {
     let contents = [
       h(
         'span',
-        {
+        !this.isServer ? {
           ref: 'text',
           attrs: {
             'aria-label': this.text.trim()
           }
-        },
-        this.realText
+        } : {},
+        this.isServer ? this.text : this.realText
       )
     ]
 


### PR DESCRIPTION
This pull request add support SSR for SEO.
I checked it for Nuxt.

Now during the first rendering from the server comes:
```
<div style="overflow:hidden;">
    <span style="box-shadow:transparent 0 0;">
        <span>long long text END</span>
        <span>READ MORE</span>
    </span>
</div>
```
And then, at the front, all the vue-clamp magic is fulfilled.