### PR TITLE
feat: improve clamp runtime and stress playground

### DIFF
--- a/journey/design.md
+++ b/journey/design.md
@@ -39,6 +39,8 @@
   - `WrapClamp` as the canonical wrapped-item component name
 - There is no default export.
 - Public declaration types live in `packages/vue-clamp/src/types.ts`.
+- Component implementation files do not re-export public declaration types; type exports stay in
+  `types.ts` and the root package barrel so the public surface remains auditable.
 - `LineClamp` is the text-only multiline component.
 - `RichLineClamp` is the rich-html multiline component.
 - `LineClamp` `location` accepts the keyword aliases `start`, `middle`, and `end`, plus numeric ratios from `0` to `1`.
@@ -91,7 +93,7 @@
     expanded/clamped state, exposed actions, queued recomputes, `ResizeObserver`, font-load
     invalidation, and same-flush `onUpdated` invalidation
   - `packages/vue-clamp/src/text.ts` for grapheme/word boundary preparation, kept-count text
-    generation, text clamp search, location normalization, and native one-line eligibility helpers
+    generation, text clamp search, and location normalization
   - `packages/vue-clamp/src/rich.ts` for rich-text parsing, runtime inline-flow classification,
     logical-run preprocessing, boundary slicing, and rich clamp search
   - `packages/vue-clamp/src/layout.ts` for the remaining shared primitives worth centralizing:
@@ -106,6 +108,8 @@
   - the visible rich HTML is patched directly into the shared `body` part
   - no image-load settlement; inline rich images must provide stable layout dimensions up front
 - Shared code stays in small helpers instead of a large base shell.
+- Internal helper contracts use named input objects once a call would otherwise require several
+  same-shaped positional values, especially DOM elements and warm-start hints.
 - `LineClamp` and `RichLineClamp` now share one narrow internal shell helper rather than
   duplicating the same lifecycle shell:
   - root/content/body/before/after refs
@@ -113,7 +117,18 @@
   - queued recomputes
   - resize/font invalidation
   - same-flush `onUpdated` invalidation
+  - recompute callbacks receive only the shared expanded ref; component-specific refs remain local
+    to each component closure
   - the actual clamp logic still stays local to each component
+- `LineClamp` native clamping is represented internally as single-line versus multi-line modes
+  rather than a boolean or CSS-mechanism-specific strings:
+  - `"single-line"` for the exact one-line end/grapheme/default-ellipsis subset
+  - `"multi-line"` for the exact multiline end/grapheme/default-ellipsis subset when `maxHeight`
+    and `after` are absent and browser support is present
+  - `null` for measured DOM clamping
+- Multiline native `line-clamp` allows `before` slot content because it is a prefix inside the same
+  formatting context. It excludes `after` slot content because native CSS cannot reserve suffix
+  space while clamping the body.
 - `InlineClamp` is a small measured single-line component:
   - one `inline-block` root that clips to its available width
   - optional fixed `start` and `end` segments in normal inline flow
@@ -189,8 +204,8 @@
     - candidate output is generated from structural boundary decisions instead of serialized HTML
     - clamped rich output appends the ellipsis as a plain text node at the `body` root, even when
       the truncation point is inside an inline element such as `code`, `strong`, or `a`
-    - parsed rich preprocessing now caches text boundary metadata once per `html` source and reuses
-      it across width, slot, and font reclamps
+    - parsed rich preprocessing prepares text boundary metadata once per parsed source instance and
+      reuses it across width, slot, and font reclamps for that instance
     - rich preparation no longer carries its own support flag; support is decided only from the
       rendered layout at clamp time
     - unchanged content still validates the rendered rich layout, but now exits before logical-run
@@ -216,7 +231,21 @@
   - collapsed states are measured from the real rendered `before` / items / `after` sequence
   - the engine settles by shrinking to a fitting prefix, then probing upward one item at a time
   - measurements come from the rendered content DOM directly instead of a separate per-item ref cache
+  - large grow cases remain linear because each candidate can change arbitrary slot output and item
+    widths; cache/hint variants stay deferred until real component workloads prove a user-visible
+    win
+  - `hiddenItems` remains the public slot prop and is sliced directly from the current item array
   - keep item order logical in the DOM so RTL works through inherited browser direction
+
+### SSR direction
+
+- The preferred SSR direction remains a DOM-preserving visual skeleton rather than approximate
+  native CSS fallback.
+- The package currently has no stylesheet delivery contract or CSS side-effect entry. Because the
+  skeleton requires media-aware CSS such as `@media (scripting: enabled)` to keep full content
+  visible for no-JS users, it is deferred until the CSS delivery contract is designed.
+- Exact native SSR subsets may still render full content with native styles when the component can
+  prove semantic equivalence, but unsupported browsers must hydrate into the measured DOM path.
 
 ### Reactivity and trade-offs
 
@@ -354,6 +383,17 @@
     checkboxes align predictably
   - on narrow screens, each shared-controls bar collapses behind a compact toggle and expands in
     place to avoid cramped wrapping
+  - the demo section has a manual stress playground modal for high-count workloads across all four
+    public components:
+    it opens with the currently active component selected, renders 10-1000 real instances on a
+    logarithmic count slider, switches between `LineClamp`, `RichLineClamp`, `InlineClamp`, and
+    `WrapClamp`, scales text length or wrapped item count, chooses one active `maxLines` or
+    `maxHeight` limit mode at a time, shares one width slider across every item, and keeps the FPS
+    meter scoped to that modal instead of the normal demo surface. When the `LineClamp` workload
+    matches the native CSS fast-path conditions, the playground shows a compact native marker. It
+    locks page scroll, keeps keyboard focus inside the modal, and stays in a centered section after
+    the normal examples. It loads only when opened because it is diagnostic tooling rather than the
+    primary demo path.
 - The website component tabs now have stable direct-link hashes:
   - `#line-clamp`
   - `#rich-line-clamp`
@@ -376,9 +416,17 @@
   - the page body is initialized from the root app and bridged with `data-overlayscrollbars-initialize`
     on `html` and `body`
   - shared horizontal containers use one small directive-backed helper
-  - the current targets are the page body, demo preview frames, and code blocks
+  - the OverlayScrollbars library and stylesheet load asynchronously on first decorated scroll
+    surface instead of joining the primary website bundle
+  - the current targets are the page body, demo preview frames, code blocks, and the stress
+    playground modal/workload scroll areas
   - `ComponentTabs` stays on its native horizontal scroller so its bespoke mobile overflow behavior
     remains independent from the shared scrollbar layer
+- The website keeps non-primary presentation tooling out of the initial `App.vue` bundle:
+  - `CodeBlock.vue` is an async component
+  - Shiki highlighting lives in `packages/website/src/highlight.ts` and loads after mount, while
+    code blocks render plain `<pre><code>` content until highlighted HTML is ready
+  - the stress playground remains an async component because it is diagnostic tooling
 - The website now splits generic and specialized tab controls more cleanly:
   - `packages/website/src/PillControls.vue` is the reusable switcher for demo preset groups
   - the installation block keeps its original dedicated tab-strip styling

--- a/journey/design.md
+++ b/journey/design.md
@@ -389,8 +389,8 @@
     place to avoid cramped wrapping
   - the demo section has a manual stress playground modal for high-count workloads across all four
     public components:
-    it opens with the currently active component selected, renders 10-1000 real instances on a
-    logarithmic count slider, switches between `LineClamp`, `RichLineClamp`, `InlineClamp`, and
+    it opens with the currently active component selected, renders 10-200 real instances on a
+    linear count slider, switches between `LineClamp`, `RichLineClamp`, `InlineClamp`, and
     `WrapClamp`, scales text length or wrapped item count, chooses one active `maxLines` or
     `maxHeight` limit mode at a time, shares one width slider across every item, and keeps the FPS
     meter scoped to that modal instead of the normal demo surface. When the `LineClamp` workload

--- a/journey/design.md
+++ b/journey/design.md
@@ -94,6 +94,8 @@
     invalidation, and same-flush `onUpdated` invalidation
   - `packages/vue-clamp/src/text.ts` for grapheme/word boundary preparation, kept-count text
     generation, text clamp search, and location normalization
+  - `packages/vue-clamp/src/native.ts` for the narrow native CSS text-clamp subset:
+    eligibility checks, native styles, CSS support detection, and native overflow reads
   - `packages/vue-clamp/src/rich.ts` for rich-text parsing, runtime inline-flow classification,
     logical-run preprocessing, boundary slicing, and rich clamp search
   - `packages/vue-clamp/src/layout.ts` for the remaining shared primitives worth centralizing:
@@ -126,6 +128,8 @@
   - `"multi-line"` for the exact multiline end/grapheme/default-ellipsis subset when `maxHeight`
     and `after` are absent and browser support is present
   - `null` for measured DOM clamping
+- Native CSS clamp eligibility and style details stay outside `LineClamp.ts`; the component only
+  resolves the mode for the current render/recompute and applies the resulting text state.
 - Multiline native `line-clamp` allows `before` slot content because it is a prefix inside the same
   formatting context. It excludes `after` slot content because native CSS cannot reserve suffix
   space while clamping the body.

--- a/journey/logs/281-1_4-future-outlook-implementation.md
+++ b/journey/logs/281-1_4-future-outlook-implementation.md
@@ -1,0 +1,30 @@
+# 1.4 future outlook implementation log
+
+## 2026-05-02
+
+- Created `feat/1-4-future-outlook` from `main`.
+- Ran `vp install`; lockfile was already current.
+- Read `journey/design.md` and `journey/research/281-1_4-future-outlook.md`.
+- Split the outlook into serial shared-contract work and parallel component work.
+- Added `RichLineClamp` development diagnostics for unsupported inline-layout fallback. The warning
+  is dev-gated, deduped per fallback reason, and production-quiet when no dev environment flag is
+  present.
+- Kept rich preparation uncached after review because sharing parsed rich metadata would add
+  ownership and eviction complexity without a clear component-level payoff.
+- Kept `WrapClamp` on the simple live-DOM shrink-then-grow loop, preserving exact after-slot
+  measurement and the existing `hiddenItems` slot prop semantics.
+- Implemented the shared text/layout foundation:
+  - explicit native line clamp modes
+  - multiline native eligibility excluding `after`
+  - lower-allocation numeric line boxes in `fitsContent`
+  - text fit controllers so final candidate application can avoid a redundant layout read
+  - lower-memory word boundary checks without a `Set`
+- Recorded the SSR skeleton constraint in `journey/design.md`: it needs a stylesheet delivery
+  contract before implementation, so this pass keeps SSR to exact native subsets.
+- Completed three review/simplification passes:
+  - simplified native content style selection in `LineClamp`
+  - trimmed unused rich diagnostic typing
+  - avoided caching a false native `line-clamp` support result when `CSS.supports` is unavailable,
+    so non-browser environments do not poison later browser support checks
+- Verification completed with `vp check`, `vp test`, targeted browser contract tests, and
+  `vp run build`.

--- a/journey/logs/281-1_4-future-outlook-implementation.md
+++ b/journey/logs/281-1_4-future-outlook-implementation.md
@@ -24,7 +24,7 @@
 - Completed three review/simplification passes:
   - simplified native content style selection in `LineClamp`
   - trimmed unused rich diagnostic typing
-  - avoided caching a false native `line-clamp` support result when `CSS.supports` is unavailable,
-    so non-browser environments do not poison later browser support checks
+  - kept native `line-clamp` support detection cached because CSS capability is stable for the
+    browser runtime once checked
 - Verification completed with `vp check`, `vp test`, targeted browser contract tests, and
   `vp run build`.

--- a/journey/logs/282-demo-stress-playground.md
+++ b/journey/logs/282-demo-stress-playground.md
@@ -1,0 +1,31 @@
+# Demo stress playground log
+
+## 2026-05-03
+
+- Added a website-only stress playground modal opened from the demo section.
+- Moved the FPS monitor into the stress playground and removed the global demo FPS checkbox.
+- The playground uses real `LineClamp` instances, a logarithmic 10-1000 component count slider,
+  shared width control, and separate `maxLines` / `maxHeight` sliders.
+- Desktop uses a centered scrollable modal; mobile uses a full-screen modal.
+- Added browser coverage for opening the playground, seeing the FPS meter, and updating workload
+  controls.
+- Added overlay-scrollbar instances to both the modal scroll viewport and the workload scroll
+  viewport.
+- Replaced the basic body overflow lock with a fixed-position scroll lock that restores the previous
+  page scroll position and inline styles on close.
+- Extended the playground from a LineClamp-only workload to a switchable workload for `LineClamp`,
+  `RichLineClamp`, `InlineClamp`, and `WrapClamp`.
+- Opening the playground from a component tab now selects that component by default.
+- Added a payload scale control: text/rich/inline cases scale repeated text, and wrapped-item cases
+  scale the generated item count.
+- Changed stress limit controls to a single active `maxLines` or `maxHeight` mode instead of
+  rendering both modes at once.
+- Renamed the text payload control to text length and moved the stress playground trigger after the
+  normal examples so diagnostic tooling does not lead the demo section.
+- Removed explicit word-boundary stress props so the playground follows component defaults, and added
+  a compact native marker for `LineClamp` workloads that match the CSS fast path.
+- Moved the stress playground trigger into its own centered section between Examples and Usage.
+- Simplified native clamp mode naming to single-line versus multi-line while keeping CSS details in
+  the playground marker metadata.
+- Verified with `vp check`, `vp test`, `vp run test:browser`, and a manual browser pass at
+  `http://localhost:5175/`.

--- a/journey/logs/282-demo-stress-playground.md
+++ b/journey/logs/282-demo-stress-playground.md
@@ -4,7 +4,7 @@
 
 - Added a website-only stress playground modal opened from the demo section.
 - Moved the FPS monitor into the stress playground and removed the global demo FPS checkbox.
-- The playground uses real `LineClamp` instances, a logarithmic 10-1000 component count slider,
+- The playground uses real clamp component instances, a linear 10-200 component count slider,
   shared width control, and separate `maxLines` / `maxHeight` sliders.
 - Desktop uses a centered scrollable modal; mobile uses a full-screen modal.
 - Added browser coverage for opening the playground, seeing the FPS meter, and updating workload

--- a/journey/logs/283-cleanup-pass.md
+++ b/journey/logs/283-cleanup-pass.md
@@ -1,0 +1,13 @@
+# Cleanup pass log
+
+## 2026-05-03
+
+- Reviewed the current branch changes as one implementation pass across library native clamp logic, text fitting, InlineClamp, and stress playground code.
+- Renamed native clamp internals around domain intent:
+  - `NativeClampMode` now represents `"single-line" | "multi-line"`.
+  - `getNativeMode` takes named constraints instead of a positional argument list.
+  - slot-specific native eligibility is handled by a short local mode picker.
+- Kept `displayTextForKeptCount` unchanged because it is an established helper name that describes a concrete transformation.
+- Removed a redundant InlineClamp text write because `clampTextToFit` now leaves controller callers on the returned candidate.
+- Cleaned stress playground naming and workload construction so the active surface only builds the payload it renders.
+- Reviewed RichLineClamp fallback diagnostics and kept the development warning because unsupported rich layout otherwise fails safe but silently. Simplified the implementation by resolving the development runtime once and making rich clamp fallback results discriminated by `fallback`.

--- a/journey/logs/284-uncommitted-change-review.md
+++ b/journey/logs/284-uncommitted-change-review.md
@@ -1,0 +1,19 @@
+# Uncommitted change review log
+
+## 2026-05-03
+
+- Reviewed the current uncommitted branch changes by area: library runtime, tests, website stress
+  playground, dependencies, and journey records.
+- Kept the library runtime changes that directly serve the 1.4 goals: conservative native
+  single-line/multi-line `LineClamp` paths, text final-apply controllers, numeric line-box grouping,
+  and development-only rich fallback diagnostics.
+- Removed newly added type noise and redundant browser coverage that did not protect a distinct
+  user-facing contract.
+- Kept the stress playground as manual diagnostic tooling and scoped the FPS meter to that modal.
+  Simplified its copy so it does not present itself as automated performance-regression tooling.
+- Lazy-loaded the stress playground so `stats.js` and the high-count diagnostic UI do not join the
+  primary website bundle.
+- Added a local modal focus trap so scroll lock and `aria-modal` do not leave keyboard focus free to
+  move into the background page.
+- Aligned native multiline support detection with rendering by writing both standard `line-clamp`
+  and prefixed `-webkit-line-clamp` styles.

--- a/journey/logs/285-website-code-split.md
+++ b/journey/logs/285-website-code-split.md
@@ -1,0 +1,19 @@
+# Website code split log
+
+## 2026-05-03
+
+- Baseline after the stress playground lazy split still had a large primary website bundle:
+  `index-BHI7KZoe.js` at 783.90 kB / 138.67 kB gzip, plus an eager
+  `overlayScrollbars-ChjvSAhT.js` chunk at 123.83 kB / 49.39 kB gzip.
+- Moved Shiki setup and language/theme imports into `packages/website/src/highlight.ts`, loaded by
+  dynamic import after mount. Code blocks keep a plain-code fallback until highlighted HTML is ready.
+- Converted `CodeBlock.vue` to an async component and kept the stress playground async.
+- Changed `packages/website/src/overlayScrollbars.ts` so the OverlayScrollbars library and CSS are
+  loaded by dynamic import on first decorated scroll surface instead of at module evaluation time.
+- Production build after the split:
+  - primary website JS: `index-CDyihdvS.js` 86.81 kB / 19.43 kB gzip
+  - lazy highlighting chunk: `highlight-DD1uq7h-.js` 694.02 kB / 118.59 kB gzip
+  - lazy code block chunk: `CodeBlock-DjCNK5gE.js` 2.35 kB / 1.21 kB gzip
+  - lazy OverlayScrollbars runtime chunks: `overlayScrollbars-GmCmuAx1.js` 63.59 kB /
+    25.41 kB gzip and `overlayscrollbars-2WRqfFAI.js` 29.87 kB / 14.75 kB gzip
+- Verified with `vp check`, `vp test`, `vp run test:browser`, and `vp run build`.

--- a/journey/logs/286-internal-api-simplification.md
+++ b/journey/logs/286-internal-api-simplification.md
@@ -1,0 +1,17 @@
+# Internal API simplification log
+
+## 2026-05-03
+
+- Started a focused pass on recently added internal contracts after reviewing `text.ts`,
+  `LineClamp.ts`, `rich.ts`, and `RichLineClamp.ts`.
+- Moved native CSS eligibility and overflow probing out of `text.ts`; native single-line/multiline
+  selection now stays local to `LineClamp`.
+- Shortened rich internals to `prepareRich`, `patchRich`, `clampRich`, `PreparedRich`, and
+  `RichState`; `patchRich` now takes `{ from, to, target }` and `clampRich` takes a named probe
+  object instead of positional DOM elements.
+- Changed `clampTextToLayout` to take named DOM inputs (`root`, `content`, `target`) plus clamp
+  metadata, so callers no longer depend on a long positional contract.
+- Removed rich fallback reason diagnostics. Unsupported rich layout still falls back to original
+  HTML, but the internal contract is back to a simple boolean fallback state.
+- Validation passed: `vp check --fix`, `vp test`, `vp run test:browser`, and `vp run build`.
+  Browser tests still print the existing ResizeObserver loop warning, but all 82 browser tests pass.

--- a/journey/logs/287-module-contract-full-scan.md
+++ b/journey/logs/287-module-contract-full-scan.md
@@ -1,0 +1,23 @@
+# Module contract full scan log
+
+## 2026-05-04
+
+- Started a full pass over internal module contracts after simplifying rich fallback diagnostics.
+- Scanned all `packages/vue-clamp/src` exports/imports and confirmed the root package surface still
+  comes only from `index.ts` plus public declarations in `types.ts`.
+- Removed duplicate component-file type re-exports from `InlineClamp.ts` and `WrapClamp.ts`.
+- Kept `PreparedText`, `TextClampResult`, `PreparedRich`, and `RichState` exported because component
+  modules use them as real cross-module state contracts; shortened purely local type names inside
+  `text.ts`, `rich.ts`, and `multiline.ts`.
+- Changed `clampTextToFit` to a named input object and updated `InlineClamp`, text tests, and the
+  browser benchmark wrapper to match.
+- Removed `splitGraphemes` and the exported search hint type; tests now validate grapheme
+  preparation through `prepareText` instead of a test-only helper export.
+- Narrowed `useMultilineClamp`'s recompute contract from the whole shell state object to only the
+  shared expanded ref.
+- Revisited object-parameter trade-offs for rich helpers: `patchRich` is back to a positional
+  signature because it is called inside the rich search loop and has a stable, compact argument
+  order; `clampRich` keeps a named options object because it is the cross-module entry point with
+  probe, state, hint, and layout-limit fields.
+- Validation passed: `vp check`, `vp test`, `vp run test:browser`, and `vp run build`. Browser
+  tests still print the existing ResizeObserver loop warning, but all 81 browser tests pass.

--- a/journey/plans/281-1_4-future-outlook-implementation.md
+++ b/journey/plans/281-1_4-future-outlook-implementation.md
@@ -1,0 +1,61 @@
+# 1.4 future outlook implementation
+
+## Scope
+
+Implement the 1.4+ future-outlook items that can land without broad public API expansion:
+
+- Expand internal `LineClamp` native modes from single-line text overflow to conservative multiline `line-clamp`.
+- Reduce text measured-path overhead without changing clamp behavior.
+- Add development diagnostics for `RichLineClamp`; keep preparation ownership simple unless a
+  repeated-source improvement is proven in real component workloads.
+- Preserve `WrapClamp` grow correctness with exact DOM measurement and `hiddenItems`; defer
+  capacity hints and slice memoization unless statistics show a meaningful user-visible win.
+
+The following outlook items are explicitly non-goals for this pass:
+
+- No public `strategy` prop.
+- No Pretext subpath or package. The outlook frames this as 1.5+ exploration that needs accuracy data first.
+- No default approximate SSR native fallback.
+- No inline pre-hydration exact clamping runtime.
+
+SSR skeleton is conditional in this pass. If the existing library structure offers a clean DOM/CSS hook without introducing a new required stylesheet or changing the public API contract, implement it. If not, record the blocker in `journey/design.md` and keep the exact native SSR subset covered by tests.
+
+## Serial work
+
+1. Branch, install, and baseline context.
+2. Write this plan and keep `journey/logs/281-1_4-future-outlook-implementation.md` updated for non-trivial decisions.
+3. Establish shared contracts first:
+   - internal native mode type and detection rules
+   - lower-allocation layout fit helper
+   - text search final-apply behavior
+4. Integrate subagent changes and resolve cross-file consistency.
+5. Run at least three simplification/review passes:
+   - implementation correctness pass
+   - abstraction/API-surface pass
+   - engineering simplification/perf pass
+6. Run `vp check` and `vp test`; run browser contract subsets that cover touched behavior.
+
+## Parallel work
+
+These can proceed independently after the shared contracts are understood:
+
+- `LineClamp` and text hot path:
+  - Native mode split: `"single-line"` / `"multi-line"` / `null`.
+  - Multiline native only for exact end/grapheme/default ellipsis/no maxHeight/no after/supported browser.
+  - Tests for before allowed, after excluded, and clamped-state detection.
+- Rich path:
+  - Development-only diagnostics for unsupported rich layout fallback.
+  - Keep rich preparation uncached in this pass until repeated-source ownership and eviction have a
+    clear component-level payoff.
+  - Browser contract cases for repeated identical HTML and unsupported fallback diagnostics.
+- Wrap path:
+  - Keep the simple shrink-then-linear-grow live DOM loop.
+  - Preserve `hiddenItems` without adding slice memoization until allocation-sensitive evidence
+    shows it matters.
+  - Browser contract cases for large lists and after digit-width boundaries.
+
+## Verification
+
+- `vp check`
+- `vp test`
+- targeted browser tests for clamp/rich/wrap/inline where changed behavior is covered

--- a/journey/plans/282-demo-stress-playground.md
+++ b/journey/plans/282-demo-stress-playground.md
@@ -1,0 +1,21 @@
+# Demo stress playground
+
+## Goal
+
+Add an interactive website playground for manual stress testing many clamp component instances at once.
+
+## Scope
+
+- Add a demo control that opens a stress playground modal.
+- Desktop modal should be centered and scrollable; mobile modal should use the full viewport.
+- The playground should render a configurable number of examples from 10 to 1000 with a logarithmic slider.
+- Controls should include shared width, `maxLines`, and `maxHeight` sliders.
+- The rendered workload should use real `vue-clamp` components rather than synthetic placeholders.
+- Keep this as manual demo tooling, not automated performance-regression infrastructure.
+
+## Verification
+
+- `vp check`
+- `vp test`
+- `vp run test:browser`
+- Browser test coverage for opening the playground and updating the workload controls.

--- a/journey/plans/282-demo-stress-playground.md
+++ b/journey/plans/282-demo-stress-playground.md
@@ -8,7 +8,7 @@ Add an interactive website playground for manual stress testing many clamp compo
 
 - Add a demo control that opens a stress playground modal.
 - Desktop modal should be centered and scrollable; mobile modal should use the full viewport.
-- The playground should render a configurable number of examples from 10 to 1000 with a logarithmic slider.
+- The playground should render a configurable number of examples from 10 to 200 with a linear slider.
 - Controls should include shared width, `maxLines`, and `maxHeight` sliders.
 - The rendered workload should use real `vue-clamp` components rather than synthetic placeholders.
 - Keep this as manual demo tooling, not automated performance-regression infrastructure.

--- a/journey/plans/283-cleanup-pass.md
+++ b/journey/plans/283-cleanup-pass.md
@@ -1,0 +1,18 @@
+# Cleanup pass
+
+## Goal
+
+Sweep the current branch changes as a cohesive implementation, not as isolated naming fixes. Preserve behavior while simplifying naming, helper boundaries, and recently added demo/stress-playground code.
+
+## Scope
+
+- Review recently changed library code around clamp preparation, native clamp mode selection, layout helpers, rich/text/wrap clamp flows, and tests.
+- Review recently added website demo code, including stress playground, FPS meter, overlay scrollbar integration, and demo controls.
+- Keep changes behavior-preserving unless a bug or inconsistency is found.
+
+## Checks
+
+- Prefer clearer names that describe domain intent rather than CSS implementation details.
+- Remove helper abstractions that do not carry their weight.
+- Keep public API and documented behavior unchanged.
+- Run `vp check`, `vp test`, `vp run test:browser`, and `vp run build`.

--- a/journey/plans/284-uncommitted-change-review.md
+++ b/journey/plans/284-uncommitted-change-review.md
@@ -1,0 +1,26 @@
+# Uncommitted change review
+
+## Goal
+
+Review every uncommitted addition from the current branch and reduce it to the smallest implementation that still serves the 1.4 goals.
+
+## Review questions
+
+- Is this required for the current product/runtime goal?
+- Is the implementation already the simplest reasonable version?
+- Is there over-design, over-abstraction, or duplicated responsibility?
+- Can it be deleted, simplified, or reused from an existing module?
+
+## Scope
+
+- Library runtime changes in `packages/vue-clamp/src`.
+- Browser and unit tests in `packages/vue-clamp/tests`.
+- Website demo, stress playground, overlay scrollbar, and FPS meter changes.
+- Journey plans, logs, research, and design updates.
+
+## Validation
+
+- Run `vp check`.
+- Run `vp test`.
+- Run `vp run test:browser`.
+- Run `vp run build`.

--- a/journey/plans/285-website-code-split.md
+++ b/journey/plans/285-website-code-split.md
@@ -1,0 +1,21 @@
+# Website code split
+
+## Goal
+
+Reduce the website's initial JavaScript cost by moving non-primary dependencies out of the
+eager `App.vue` path.
+
+## Scope
+
+- Split syntax highlighting into an async chunk with a plain-code fallback.
+- Split code block UI from the main app component.
+- Load OverlayScrollbars only when a decorated scroll container mounts.
+- Keep the stress playground lazy-loaded.
+
+## Validation
+
+- Compare production build chunks before and after.
+- Run `vp check`.
+- Run `vp test`.
+- Run `vp run test:browser`.
+- Run `vp run build`.

--- a/journey/plans/286-internal-api-simplification.md
+++ b/journey/plans/286-internal-api-simplification.md
@@ -1,0 +1,18 @@
+# Internal API simplification
+
+## Goal
+
+Reduce recently added internal module contracts without changing runtime behavior.
+
+## Scope
+
+- Move native CSS clamp decisions out of `text.ts` and back into `LineClamp.ts`.
+- Shorten `rich.ts` exports where the module name already provides context.
+- Replace wide positional rich clamp arguments with a single named input object.
+- Replace the wide text DOM clamp argument list with a named input object.
+
+## Validation
+
+- `vp check`
+- `vp test`
+- `vp run test:browser`

--- a/journey/plans/287-module-contract-full-scan.md
+++ b/journey/plans/287-module-contract-full-scan.md
@@ -1,0 +1,25 @@
+# Module contract full scan
+
+## Goal
+
+Review all internal module-to-module and module-local contracts in `packages/vue-clamp/src` and remove avoidable complexity without changing public behavior.
+
+## Scope
+
+- Public barrel: keep `index.ts` limited to supported public components and declaration types.
+- Shared modules: verify `layout.ts`, `multiline.ts`, `props.ts`, `search.ts`, `slot.ts`, `text.ts`, and `rich.ts` expose only contracts needed by component modules or tests.
+- Component modules: check whether helper names, object inputs, and state contracts are still smaller than the positional or diagnostic contracts they replaced.
+- Tests/benchmarks: keep internal helper usage aligned with the simplified contracts.
+
+## Constraints
+
+- Do not change the public package API unless the scan finds an accidental leak.
+- Preserve current runtime behavior, including rich fallback-to-source behavior for unsupported layout.
+- Prefer deleting thin abstractions and diagnostic-only contracts over moving them around.
+
+## Validation
+
+- `vp check`
+- `vp test`
+- `vp run test:browser`
+- `vp run build`

--- a/journey/research/281-1_4-future-outlook.md
+++ b/journey/research/281-1_4-future-outlook.md
@@ -1,0 +1,1221 @@
+# vue-clamp 1.4+ Future Outlook
+
+This document outlines a future direction for `vue-clamp` after 1.3.0. The goal is not to redesign the library or expand the public API surface aggressively. The goal is to build on the current implementation and make the existing primitives faster, more predictable, and more robust across SSR, native CSS opportunities, rich content, and large wrapped item sets.
+
+The main principle for 1.4+ should be:
+
+```text
+Keep the public API focused on clamping semantics.
+Keep implementation strategies internal.
+Use faster paths only when they are semantically equivalent.
+Fall back to measured DOM truth whenever equivalence is uncertain.
+```
+
+## 1. Baseline in 1.3.0
+
+The 1.3.0 implementation already has several important performance and correctness foundations.
+
+### 1.1 Shared multiline measurement infrastructure
+
+`LineClamp` and `RichLineClamp` share a multiline measurement shell that handles:
+
+```text
+ResizeObserver based recomputation
+font loading driven recomputation
+coalesced recompute scheduling
+layout signature checks
+same-flush Vue update handling
+connected DOM probes
+```
+
+This means future work should avoid duplicating scheduling and measurement behavior in each component. Any new optimization should ideally plug into this existing recompute pipeline.
+
+### 1.2 Text clamping already uses prepared boundaries and warm search
+
+The plain text path already prepares text into boundary offsets and uses a search helper with warm hints. This avoids naive character-by-character truncation.
+
+The current design is already centered around:
+
+```text
+prepare text once
+search candidate lengths
+measure actual browser layout
+reuse previous clamp result as a hint
+```
+
+This is the right model. Future work should reduce the number and cost of DOM probes, not replace the correctness model wholesale.
+
+### 1.3 Native single-line path already exists
+
+`LineClamp` already has a native path for the narrow case where browser `text-overflow` semantics match the component semantics.
+
+This path is intentionally conservative. It should remain conservative, but it can be extended in 1.4+ to cover more exact native cases.
+
+### 1.4 RichLineClamp is structural, not string based
+
+`RichLineClamp` parses and prepares trusted inline HTML, measures candidates in a connected probe, and patches structural clamp decisions back into the visible DOM.
+
+This is a much heavier path than plain text. Future optimizations here should be careful and evidence driven. The main opportunities are caching, diagnostics, and benchmark coverage rather than aggressive algorithm replacement.
+
+### 1.5 WrapClamp measures actual atomic boxes
+
+`WrapClamp` treats before, items, and after as atomic inline-flex boxes. It measures their real browser geometry and settles visible item count based on actual line wrapping.
+
+This is necessary because item widths and after slot output are arbitrary. The implementation should preserve that correctness model.
+
+### 1.6 Benchmarks exist, but should become versioned assets
+
+The project already has benchmark scripts for rich and wrap cases. The next step is to make benchmark results persistent, comparable across releases, and useful for regression detection.
+
+---
+
+## 2. Guiding Principles for 1.4+
+
+### 2.1 Do not add a public `strategy` prop
+
+Users should not have to choose between internal mechanisms such as:
+
+```text
+native
+measured
+pretext
+binary
+skeleton
+early runtime
+```
+
+Those are implementation details. The component should choose the fastest safe implementation automatically.
+
+Recommended direction:
+
+```text
+Public API:
+  Describe desired clamping behavior.
+
+Internal implementation:
+  Pick the best safe path based on props, slots, browser support, text shape, and measurement results.
+```
+
+### 2.2 Preserve existing DX
+
+In particular, `WrapClamp` should continue exposing `hiddenItems`.
+
+`hiddenItems` is not merely a count. It enables:
+
+```text
++N indicators
+tooltips
+popover content
+overflow menus
+remaining item summaries
+localized after content
+custom item rendering
+```
+
+Do not replace it with `hiddenCount`, a getter, or a lower-level API. If there is a cost to slicing hidden items, optimize internally without weakening the public slot interface.
+
+### 2.3 Keep native paths semantically exact
+
+Native CSS should only be used when it produces the same visual and semantic result as the component.
+
+Approximate native rendering is not acceptable for cases involving:
+
+```text
+custom ellipsis
+after slots
+middle or start clamping
+word boundaries
+rich inline structure
+arbitrary WrapClamp after content
+```
+
+When native CSS cannot express the exact semantics, the library should keep using the measured DOM path.
+
+### 2.4 Treat DOM measurement as the source of truth
+
+Even if faster predictors are introduced, such as Pretext, the final result should still be verified against real browser layout unless the native path is known to be semantically exact.
+
+The long-term model should be:
+
+```text
+Predict fast when possible.
+Verify with DOM when needed.
+Fallback to existing measured search when prediction is uncertain.
+```
+
+---
+
+## 3. LineClamp Native Fast Path Expansion
+
+This is one of the most direct 1.4+ performance opportunities.
+
+### 3.1 Current situation
+
+`LineClamp` already has a native path for single-line end clamping with default ellipsis and grapheme boundary. It uses browser `text-overflow`.
+
+This path should be kept, but the internal decision should be made more explicit.
+
+### 3.2 Introduce internal native modes
+
+Instead of treating native clamping as one boolean branch, use internal modes:
+
+```ts
+type NativeClampMode = "single-line" | "multi-line" | null;
+```
+
+This does not require a public API change.
+
+### 3.3 Single-line native mode
+
+For `maxLines === 1`, use `text-overflow`, not `line-clamp: 1`.
+
+Conditions:
+
+```ts
+maxLines === 1 &&
+  maxHeight == null &&
+  location === "end" &&
+  boundary === "grapheme" &&
+  ellipsis === "…" &&
+  !expanded;
+```
+
+Important point:
+
+```text
+before and after can both be supported in this mode.
+```
+
+The single-line native layout can use an inline-flex structure:
+
+```text
+before: fixed
+body: flexible, min-width: 0, text-overflow
+after: fixed
+```
+
+This preserves the intended visual model:
+
+```text
+[before] [clamped body…] [after]
+```
+
+### 3.4 Why not use `line-clamp: 1`
+
+`text-overflow` and `line-clamp: 1` are not visually equivalent.
+
+`text-overflow` means:
+
+```text
+Keep content on one line and ellipsize inline overflow.
+```
+
+`line-clamp: 1` means:
+
+```text
+Lay content out normally, then keep only the first line.
+```
+
+For text with natural wrapping opportunities, especially English words separated by spaces, the results can differ.
+
+Example:
+
+```text
+Original:
+Hello world from Vue
+
+Possible text-overflow result:
+Hello wor…
+
+Possible line-clamp: 1 result:
+Hello…
+```
+
+For `maxLines === 1`, `text-overflow` better matches the expected single-line truncation behavior.
+
+### 3.5 Multiline native mode
+
+For `maxLines > 1`, `line-clamp` can be used in a conservative exact subset.
+
+Conditions:
+
+```ts
+maxLines > 1 &&
+  maxHeight == null &&
+  !hasAfter &&
+  location === "end" &&
+  boundary === "grapheme" &&
+  ellipsis === "…" &&
+  !expanded &&
+  supportsLineClamp();
+```
+
+### 3.6 before is allowed in multiline native mode
+
+A `before` slot is a prefix. If `line-clamp` is applied to a shared formatting context containing both before and body, the browser naturally accounts for the prefix when laying out the first lines.
+
+The visual model remains correct:
+
+```text
+[before] [body continues and is clamped at the end]
+```
+
+Therefore:
+
+```text
+Do not exclude before from multiline native mode.
+```
+
+### 3.7 after is not allowed in multiline native mode
+
+An `after` slot is a suffix. The intended model is:
+
+```text
+[before] [clamped body…] [after]
+```
+
+Native `line-clamp` cannot reliably express this.
+
+If the after content is placed inside the clamped container, it may be clamped away.  
+If it is placed outside the clamped container, the native clamp does not know how much last-line space the after content requires.
+
+Therefore:
+
+```text
+Exclude after from multiline native mode.
+```
+
+### 3.8 Multiline native mode must remain conservative
+
+Do not use multiline native mode for:
+
+```text
+custom ellipsis
+word boundary
+middle clamping
+start clamping
+maxHeight
+expanded state
+after slot
+unsupported browsers
+```
+
+These should continue using the measured JS path.
+
+### 3.9 Native clamped state detection
+
+Single-line native mode can keep using:
+
+```ts
+scrollWidth > clientWidth;
+```
+
+Multiline native mode probably needs:
+
+```ts
+scrollHeight > clientHeight + epsilon;
+```
+
+This should be validated across browsers, fractional pixels, font loading states, and legacy `-webkit-line-clamp` behavior.
+
+If clamped state detection is unreliable, the implementation should fall back to measured JS clamping.
+
+---
+
+## 4. Plain Text Measured Path Optimizations
+
+The current measured text path is already well structured. 1.4+ should focus on reducing hot-path overhead.
+
+### 4.1 Avoid the final redundant layout read
+
+In the current flow, after the best fitting candidate is found, the implementation may still call the fit predicate again to ensure the DOM is left in the final candidate state.
+
+This can be optimized by separating candidate application from candidate testing:
+
+```ts
+function applyCandidate(text: string): void;
+
+function testCandidate(text: string): boolean;
+```
+
+During search:
+
+```text
+apply candidate
+read layout
+record whether it fits
+```
+
+After search:
+
+```text
+if the current DOM is not the best candidate:
+  apply the best candidate without another layout read
+```
+
+Benefit:
+
+```text
+One fewer forced layout read per clamp in common cases.
+```
+
+This is small per instance but meaningful across many instances or resize storms.
+
+### 4.2 Reduce allocations in line counting
+
+If line counting currently derives line identity from string keys such as:
+
+```ts
+`${rect.top}/${rect.bottom}`;
+```
+
+then each probe allocates temporary strings.
+
+A lower-allocation approach would store numeric line boxes:
+
+```ts
+type LineBox = {
+  top: number;
+  bottom: number;
+};
+```
+
+and compare with a small tolerance:
+
+```ts
+function sameLine(a: LineBox, b: LineBox): boolean {
+  return Math.abs(a.top - b.top) <= 0.5 && Math.abs(a.bottom - b.bottom) <= 0.5;
+}
+```
+
+Since line limits are usually small, a tiny array and linear comparison can be faster and lower overhead than string keys.
+
+### 4.3 Reduce memory in word boundary preparation
+
+`boundary="word"` needs to avoid cutting inside grapheme clusters. A straightforward implementation may create both word offsets and grapheme fallback offsets, then use a `Set` to check boundary safety.
+
+Possible improvements:
+
+```text
+Skip the Set for ASCII-safe text.
+Use two-pointer comparison for sorted offset arrays.
+Lazily build grapheme fallback offsets only when needed.
+```
+
+The goal is to reduce memory spikes for:
+
+```text
+long text
+CJK text
+emoji-heavy text
+mixed language text
+word boundary mode
+```
+
+This should not change behavior.
+
+---
+
+## 5. RichLineClamp Improvements
+
+`RichLineClamp` is already the heaviest primitive. 1.4+ improvements should prioritize observability, caching, and correctness-preserving speedups.
+
+### 5.1 Keep structural clamping as the model
+
+Do not regress to string-based HTML truncation. Rich clamping should continue to operate on prepared structure and real DOM measurement.
+
+The current model is appropriate:
+
+```text
+parse trusted inline HTML
+prepare structural tree
+measure candidates in connected probe
+patch structural decision into visible DOM
+fallback safely when layout is unsupported
+```
+
+### 5.2 Add dev diagnostics for unsupported rich content
+
+When rich clamping falls back because markup or layout is unsupported, users should be able to understand why.
+
+In development mode, provide diagnostic information for cases such as:
+
+```text
+out-of-flow descendants
+non-inline wrappers
+float
+positioned content
+unstable image dimensions
+unsupported atomic elements
+unexpected block formatting context
+```
+
+This could be exposed as:
+
+```text
+dev warning
+debug callback
+internal diagnostic event
+```
+
+The default production behavior should remain quiet and safe.
+
+### 5.3 Consider bounded preparation caching
+
+Repeated identical HTML can appear in lists, previews, and shared content blocks.
+
+A bounded LRU cache for prepared rich text could help:
+
+```text
+key: html + boundary
+value: immutable prepared rich structure
+```
+
+Requirements:
+
+```text
+Do not cache mutable DOM nodes.
+Do not share mutable clamp state.
+Put a strict size limit on the cache.
+Benchmark memory impact.
+```
+
+### 5.4 Expand rich benchmarks
+
+Rich benchmarks should include:
+
+```text
+shallow inline markup
+deeply nested inline markup
+many small text runs
+one long text run
+inline image
+svg
+custom element
+unsupported markup fallback
+font loading
+repeated identical HTML
+```
+
+Metrics should include:
+
+```text
+duration
+layout reads
+client rect reads
+bounding rect reads
+clone count
+patch count
+replaceChildren count
+fallback count
+```
+
+---
+
+## 6. WrapClamp Improvements
+
+`WrapClamp` should preserve arbitrary item and after rendering. The next optimization should improve convergence without weakening correctness.
+
+### 6.1 Preserve `hiddenItems`
+
+Keep the existing slot DX:
+
+```vue
+<template #after="{ hiddenItems }">+{{ hiddenItems.length }}</template>
+```
+
+Do not replace it with a lower-level API.
+
+### 6.2 Do not assume stable after content
+
+The `after` slot commonly depends on hidden item count:
+
+```text
++9
++10
++99
++100
+```
+
+The width changes exactly when the visible count changes.
+
+Since `after` is arbitrary Vue output, it may be:
+
+```text
+text
+button
+popover trigger
+localized label
+icon plus count
+custom component tree
+```
+
+Therefore, do not require or assume stable after width.
+
+### 6.3 Avoid binary search as the default grow algorithm
+
+Binary search requires a mostly monotonic fit predicate. With arbitrary after content, the predicate may not be reliable enough.
+
+Example:
+
+```text
+visible count changes
+hiddenItems changes
+after slot output changes
+after width changes
+line wrapping changes
+```
+
+This makes default binary search risky.
+
+### 6.4 Add capacity hints for grow cases
+
+The current linear grow behavior is correct but can be slow when the container becomes much wider.
+
+A safer optimization is to use a capacity hint:
+
+```text
+1. Detect a grow case.
+2. Estimate a candidate visible count from historical measurements.
+3. Jump to that candidate.
+4. Measure with the existing exact DOM logic.
+5. If it does not fit, shrink.
+6. If it fits, do local linear growth to settle exactly.
+```
+
+Possible hint inputs:
+
+```text
+previous container width
+new container width
+previous visible count
+average measured item width
+previous row capacity
+previous after width
+total item count
+```
+
+The key rule:
+
+```text
+The hint only improves the starting point.
+The final answer still comes from actual DOM measurement.
+```
+
+### 6.5 Trigger capacity hints selectively
+
+Do not use this path for every update.
+
+Good triggers:
+
+```text
+container width increased significantly
+total item count is large
+visible count is far from total count
+previous linear growth required many probes
+```
+
+Small lists and small resizes can stay on the current warm path.
+
+### 6.6 Optional hiddenItems slice memoization
+
+Keep returning `hiddenItems`, but internally memoize:
+
+```text
+items reference
+rendered visible count
+hiddenItems slice
+```
+
+Only recompute the slice when either the items array reference or visible count changes.
+
+This is a minor optimization and should only be added if benchmark data shows value.
+
+### 6.7 Wrap benchmarks
+
+Add cases for:
+
+```text
+20 items
+100 items
+1000 items
+variable item widths
+before slot
+after = +N
+after digit boundary: +9 to +10, +99 to +100
+container grow
+container shrink
+font loading
+after as component
+```
+
+---
+
+## 7. SSR Direction
+
+SSR is an important 1.4+ area because the current primitives depend on client-side measurement.
+
+The recommended default is not native CSS approximation. The recommended default is DOM-preserving visual skeleton.
+
+### 7.1 Why not default to native CSS fallback
+
+Native CSS fallback is not generally equivalent to `vue-clamp` semantics.
+
+It cannot faithfully represent:
+
+```text
+before and after participation
+custom ellipsis
+middle or start clamping
+word boundary
+rich inline structure
+WrapClamp after slot
+```
+
+Showing an approximate result during SSR and replacing it after hydration can produce visible jumps.
+
+For this library, a neutral pending state is often better than a wrong clamp.
+
+### 7.2 DOM-preserving visual skeleton
+
+SSR should output full content in the DOM while rendering a skeleton visually when scripting is enabled.
+
+Desired behavior:
+
+```text
+SSR DOM:
+  full original content
+
+JS enabled visual state:
+  skeleton
+
+JS disabled visual state:
+  full content
+
+After hydration and measurement:
+  exact clamped result
+```
+
+This preserves:
+
+```text
+SEO
+no-JS content
+copyability when fallback is visible
+semantic HTML
+progressive enhancement
+```
+
+### 7.3 Pending state should exist on both server and initial client render
+
+To avoid hydration mismatch:
+
+```text
+server render:
+  pending = true
+
+client hydration initial render:
+  pending = true
+
+mounted:
+  measure
+  pending = false
+  render exact result
+```
+
+Do not rely on hydration mismatch suppression as the main mechanism.
+
+### 7.4 Skeleton CSS
+
+A possible model:
+
+```css
+.vc__skeleton {
+  display: none;
+}
+
+@media (scripting: enabled) {
+  .vc--ssr-pending {
+    position: relative;
+    overflow: clip;
+    block-size: var(--vc-ssr-block-size);
+  }
+
+  .vc--ssr-pending > .vc__content {
+    opacity: 0;
+    pointer-events: none;
+    user-select: none;
+  }
+
+  .vc--ssr-pending > .vc__skeleton {
+    display: block;
+    position: absolute;
+    inset: 0;
+  }
+}
+```
+
+Do not use:
+
+```css
+display: none;
+```
+
+for the real content, since the point is to preserve the full DOM.
+
+### 7.5 Component-specific SSR behavior
+
+#### LineClamp
+
+```text
+SSR:
+  full text and slots in DOM
+  N-line skeleton visually
+
+Hydration:
+  exact text clamp
+```
+
+#### InlineClamp
+
+```text
+SSR:
+  full inline content in DOM
+  single-line skeleton visually
+
+Hydration:
+  exact inline clamp
+```
+
+#### RichLineClamp
+
+```text
+SSR:
+  full trusted inline HTML in DOM
+  multiline skeleton visually
+
+Hydration:
+  exact rich structural clamp
+```
+
+#### WrapClamp
+
+```text
+SSR:
+  full before/items/after DOM
+  wrapped skeleton visually
+
+Hydration:
+  exact visible items and exact after slot
+```
+
+### 7.6 Native exact SSR subset
+
+Native CSS can still be used during SSR when it is semantically exact.
+
+Examples:
+
+```text
+LineClamp maxLines = 1 with default end ellipsis and grapheme boundary.
+LineClamp maxLines > 1 with no after, default end ellipsis, grapheme boundary, and supported line-clamp.
+```
+
+But this should be an exact subset, not a general fallback.
+
+### 7.7 Early runtime is an optional enhancement, not the default
+
+A `react-wrap-balancer` style early runtime is possible in principle, but it should not be the default path for `vue-clamp`.
+
+The runtime is heavier, and many `vue-clamp` cases modify text, DOM structure, or slots.
+
+If explored later, limit it to:
+
+```text
+simple LineClamp
+global runtime injected once
+tiny per-component trampoline
+result handoff to client state
+```
+
+Avoid:
+
+```text
+full clamping runtime inline per component
+RichLineClamp pre-hydration exact by default
+WrapClamp pre-hydration exact by default
+```
+
+---
+
+## 8. Benchmarking as a Versioned Asset
+
+1.4+ should make benchmark data part of the release process.
+
+### 8.1 Suggested structure
+
+```text
+benchmarks/
+  scenarios/
+    line.json
+    inline.json
+    rich.json
+    wrap.json
+    ssr.json
+
+  results/
+    1.3.0/
+      chromium.json
+      webkit.json
+      firefox.json
+
+    1.4.0/
+      chromium.json
+      webkit.json
+      firefox.json
+
+  perf.md
+```
+
+### 8.2 Metrics
+
+Record:
+
+```text
+duration p50
+duration p95
+fit calls
+layout reads
+client rect reads
+bounding rect reads
+DOM writes
+Vue updates
+nextTick count
+memory estimate
+clamped state correctness
+fallback count
+```
+
+SSR metrics:
+
+```text
+pending duration
+hydration mismatch count
+skeleton to exact transition time
+visual layout delta
+no-JS fallback behavior
+```
+
+### 8.3 Regression policy
+
+Browser benchmarks are noisy. Avoid failing CI on tiny absolute differences.
+
+Use a dual threshold:
+
+```text
+relative regression > 15% or 20%
+and
+absolute regression > a minimum ms threshold
+```
+
+For example:
+
+```text
+Fail only if p95 is more than 20% slower and at least 1ms slower.
+```
+
+### 8.4 Important benchmark scenarios
+
+#### LineClamp
+
+```text
+single-line native
+single-line before
+single-line after
+single-line before + after
+multiline native no slots
+multiline native before only
+multiline measured after
+custom ellipsis
+middle clamp
+word boundary
+CJK
+emoji ZWJ
+long URL
+long unbreakable token
+font loading
+resize storm
+```
+
+#### InlineClamp
+
+```text
+short inline text
+long inline text
+before/body/after
+custom ellipsis
+RTL
+container shrink
+container grow
+```
+
+#### RichLineClamp
+
+```text
+shallow markup
+deep nested markup
+many text runs
+one long text run
+inline image
+svg
+custom element
+unsupported markup fallback
+repeated identical HTML
+```
+
+#### WrapClamp
+
+```text
+20 items
+100 items
+1000 items
+variable widths
+before slot
+after text
+after component
++9 to +10
++99 to +100
+container grow
+container shrink
+```
+
+#### SSR
+
+```text
+LineClamp skeleton
+InlineClamp skeleton
+RichLineClamp skeleton
+WrapClamp skeleton
+native exact subset
+hydration transition
+no-JS fallback
+```
+
+---
+
+## 9. Pretext as a Future Accelerator
+
+Pretext is promising, but it should not replace DOM truth.
+
+### 9.1 Role
+
+Pretext should act as:
+
+```text
+predictor
+accelerator
+candidate generator
+```
+
+not as:
+
+```text
+final authority
+```
+
+The future model should be:
+
+```text
+Pretext predicts a cut point.
+DOM verifies the candidate.
+If verification passes, use it.
+If verification fails, fall back to current measured search.
+```
+
+### 9.2 First phase: experimental entry
+
+Do not put Pretext into the default path immediately.
+
+Possible entry points:
+
+```ts
+import { LineClamp } from "vue-clamp/pretext";
+```
+
+or:
+
+```ts
+import { LineClamp } from "@vue-clamp/pretext";
+```
+
+Goals:
+
+```text
+collect accuracy data
+measure prepare cost
+compare against current measured path
+find unsupported CSS text cases
+understand simple case overhead
+```
+
+### 9.3 Second phase: internal accelerator
+
+If proven reliable, Pretext can become an internal accelerator for plain text `LineClamp`.
+
+Candidate conditions:
+
+```text
+plain text
+not rich
+not native exact subset
+text is long enough
+computed font is available
+line-height is modelable
+letter-spacing is modelable
+repeated resize occurred
+```
+
+Avoid Pretext for:
+
+```text
+short text
+obvious native single-line path
+native multiline exact subset
+complex slots
+rich content
+unmodeled CSS text behavior
+```
+
+### 9.4 Why simple cases may not matter as much
+
+If Pretext is slightly slower for simple cases, it may not affect perceived performance. But the default path should still avoid unnecessary preparation work when the current path is already cheap or native CSS can solve the case.
+
+Use thresholds rather than always-on behavior.
+
+---
+
+## 10. Smaller Correctness-Preserving Optimizations
+
+These are lower priority than native expansion, SSR, and benchmarks, but they are worth tracking.
+
+### 10.1 Candidate application without retesting
+
+Avoid final redundant layout reads by separating:
+
+```text
+apply candidate
+test candidate
+```
+
+### 10.2 Lower-allocation line counting
+
+Replace string-based line keys with numeric rect comparison.
+
+### 10.3 Lower-memory word boundaries
+
+Avoid unnecessary `Set` allocation and lazily build fallback grapheme offsets where possible.
+
+### 10.4 hiddenItems slice memoization
+
+Keep public `hiddenItems`, but memoize internal slices when safe.
+
+---
+
+## 11. Non-goals for 1.4+
+
+The following should not be part of the 1.4+ direction unless future evidence strongly changes the tradeoff.
+
+```text
+No public strategy prop.
+No locale prop.
+No replacement of hiddenItems with hiddenCount or getter.
+No assumption that WrapClamp after content is stable.
+No default binary search for arbitrary WrapClamp after content.
+No default native CSS approximation for SSR.
+No full clamping runtime inline per component.
+No default pre-hydration exact RichLineClamp.
+No default pre-hydration exact WrapClamp.
+No Pretext as a replacement for DOM verification.
+```
+
+---
+
+## 12. Suggested Roadmap
+
+### 1.4.0
+
+Focus on the highest-confidence internal improvements.
+
+```text
+Expand LineClamp native mode:
+  maxLines = 1 uses text-overflow.
+  maxLines > 1 can use line-clamp when after is absent.
+  before is allowed in both modes.
+
+Introduce SSR DOM-preserving skeleton:
+  server pending state
+  client initial pending state
+  mounted exact measurement
+  CSS variable based skeleton styling
+
+Start benchmark versioning:
+  line benchmark
+  native vs measured benchmark
+  wrap after-width benchmark
+  SSR skeleton benchmark
+```
+
+### 1.4.x
+
+Focus on correctness and performance refinement.
+
+```text
+Improve multiline native clamped-state detection.
+Add RichLineClamp dev diagnostics.
+Add WrapClamp capacity hints.
+Add benchmark regression thresholds.
+Add low-allocation layout measurement improvements.
+```
+
+### 1.5+
+
+Explore larger accelerators after benchmark infrastructure exists.
+
+```text
+Pretext experimental package or subpath.
+Prepared rich text bounded cache.
+More SSR integration helpers.
+Optional simple LineClamp early runtime experiment.
+```
+
+---
+
+## 13. Summary
+
+The 1.4+ direction should build directly on the current 1.3.0 implementation:
+
+```text
+LineClamp:
+  expand exact native fast paths.
+
+Text measured path:
+  reduce unnecessary layout reads and allocations.
+
+RichLineClamp:
+  improve diagnostics, caching, and benchmark coverage.
+
+WrapClamp:
+  preserve arbitrary after content and hiddenItems DX,
+  but improve grow convergence with capacity hints.
+
+SSR:
+  prefer DOM-preserving visual skeleton over incorrect native approximation.
+
+Benchmarking:
+  make performance data versioned and release visible.
+
+Pretext:
+  explore as a predictor and accelerator,
+  never as an unverified replacement for browser layout.
+```
+
+The library should continue to prioritize exact behavior, but become more aggressive internally when it can prove that a faster path is equivalent.

--- a/journey/research/281-1_4-future-outlook.md
+++ b/journey/research/281-1_4-future-outlook.md
@@ -276,7 +276,7 @@ An `after` slot is a suffix. The intended model is:
 
 Native `line-clamp` cannot reliably express this.
 
-If the after content is placed inside the clamped container, it may be clamped away.  
+If the after content is placed inside the clamped container, it may be clamped away.
 If it is placed outside the clamped container, the native clamp does not know how much last-line space the after content requires.
 
 Therefore:

--- a/packages/vue-clamp/src/InlineClamp.ts
+++ b/packages/vue-clamp/src/InlineClamp.ts
@@ -114,21 +114,22 @@ export const InlineClamp = defineComponent({
         return body;
       }
 
-      const nextResult = clampTextToFit(
+      const nextResult = clampTextToFit({
+        ellipsis: props.ellipsis,
+        fit: {
+          apply(candidate) {
+            bodyElement.textContent = candidate;
+          },
+          fits,
+        },
+        hint: lastTextClamp,
         prepared,
         ratio,
-        props.ellipsis,
-        (candidate) => {
-          bodyElement.textContent = candidate;
-          return fits();
-        },
         // Split affixes already own the outer spacing; preserve spaces at the
         // body edges so custom split functions keep browser-like inline flow.
-        "preserve-outer",
-        lastTextClamp,
-      );
+        spacing: "preserve-outer",
+      });
       const nextBody = nextResult.text;
-      bodyElement.textContent = nextBody;
       lastTextClamp = nextResult;
 
       return nextBody;
@@ -263,5 +264,3 @@ export const InlineClamp = defineComponent({
     };
   },
 });
-
-export type { InlineClampParts, InlineClampProps, InlineClampSplit } from "./types.ts";

--- a/packages/vue-clamp/src/InlineClamp.ts
+++ b/packages/vue-clamp/src/InlineClamp.ts
@@ -99,11 +99,11 @@ export const InlineClamp = defineComponent({
         return null;
       }
 
-      const fits = () => rootElement.scrollWidth <= limit + fitTolerance;
+      const fitsCurrentBody = () => rootElement.scrollWidth <= limit + fitTolerance;
       const prepared = preparedBody.value;
       const ratio = locationRatio.value;
 
-      if (fits()) {
+      if (fitsCurrentBody()) {
         // Store the full body as the next warm-start point so a following shrink
         // starts from the real upper bound.
         lastTextClamp = {
@@ -116,11 +116,9 @@ export const InlineClamp = defineComponent({
 
       const nextResult = clampTextToFit({
         ellipsis: props.ellipsis,
-        fit: {
-          apply(candidate) {
-            bodyElement.textContent = candidate;
-          },
-          fits,
+        fits(candidate) {
+          bodyElement.textContent = candidate;
+          return fitsCurrentBody();
         },
         hint: lastTextClamp,
         prepared,
@@ -130,6 +128,7 @@ export const InlineClamp = defineComponent({
         spacing: "preserve-outer",
       });
       const nextBody = nextResult.text;
+      bodyElement.textContent = nextBody;
       lastTextClamp = nextResult;
 
       return nextBody;

--- a/packages/vue-clamp/src/LineClamp.ts
+++ b/packages/vue-clamp/src/LineClamp.ts
@@ -2,6 +2,13 @@ import { computed, defineComponent, h, mergeProps, nextTick, ref, watch } from "
 import { cssLength, normalizeLineLimit } from "./layout.ts";
 import { useMultilineClamp } from "./multiline.ts";
 import {
+  getNativeContentStyle,
+  measureNativeClamped,
+  nativeBodyStyle,
+  nativeTextStyle,
+  resolveNativeMode,
+} from "./native.ts";
+import {
   blockAsProp,
   boundaryProp,
   ellipsisProp,
@@ -17,8 +24,6 @@ import type { CSSProperties, VNodeChild } from "vue";
 import type { LineClampExposed, LineClampSlotProps } from "./types.ts";
 import type { TextClampResult } from "./text.ts";
 
-type NativeMode = "single-line" | "multi-line";
-
 // Slot wrappers are inline-flex so before/after controls participate in the same
 // line box as text while staying atomic during measurement.
 const slotStyle: CSSProperties = {
@@ -29,59 +34,7 @@ const slotStyle: CSSProperties = {
   verticalAlign: "baseline",
 };
 
-let lineClampSupport: boolean | null = null;
-
-const nativeSingleLineContentStyle: CSSProperties = {
-  alignItems: "baseline",
-  display: "inline-flex",
-  maxWidth: "100%",
-  verticalAlign: "baseline",
-  width: "100%",
-};
-
-function makeMultilineStyle(lineLimit: number): CSSProperties {
-  return {
-    display: "-webkit-box",
-    lineClamp: String(lineLimit),
-    maxWidth: "100%",
-    overflow: "hidden",
-    verticalAlign: "baseline",
-    WebkitBoxOrient: "vertical",
-    WebkitLineClamp: String(lineLimit),
-  };
-}
-
-function getContentStyle(
-  mode: NativeMode | null,
-  lineLimit: number | undefined,
-): CSSProperties | undefined {
-  if (mode === "single-line") {
-    return nativeSingleLineContentStyle;
-  }
-
-  if (mode === "multi-line" && lineLimit !== undefined) {
-    return makeMultilineStyle(lineLimit);
-  }
-
-  return undefined;
-}
-
-// Native paths are intentionally narrow: they are only used when browser CSS
-// semantics exactly match the public props.
-const nativeSingleLineTextStyle: CSSProperties = {
-  display: "block",
-  overflow: "hidden",
-  overflowWrap: "normal",
-  whiteSpace: "nowrap",
-};
-
-const nativeSingleLineBodyStyle: CSSProperties = {
-  display: "block",
-  flex: "1 1 auto",
-  minWidth: "0",
-};
-
-const nativeSingleLineSlotStyle: CSSProperties = {
+const nativeSlotStyle: CSSProperties = {
   ...slotStyle,
   flex: "none",
 };
@@ -114,44 +67,6 @@ const emitsDef = {
   clampchange: (value: boolean) => typeof value === "boolean",
 };
 
-// Native multi-line line-clamp cannot reserve trailing after-slot content.
-// The single-line text-overflow path keeps slots in a flex row, so it remains eligible.
-function pickNativeMode(mode: NativeMode | null, hasAfterSlot: boolean): NativeMode | null {
-  if (mode === "multi-line" && hasAfterSlot) {
-    return null;
-  }
-
-  return mode;
-}
-
-function supportsLineClamp(): boolean {
-  if (lineClampSupport !== null) {
-    return lineClampSupport;
-  }
-
-  if (typeof CSS === "undefined" || typeof CSS.supports !== "function") {
-    return false;
-  }
-
-  lineClampSupport = CSS.supports("-webkit-line-clamp", "2") || CSS.supports("line-clamp", "2");
-
-  return lineClampSupport;
-}
-
-function isNativeClamped(element: HTMLElement, mode: NativeMode): boolean | null {
-  if (element.clientWidth <= 0 || element.getBoundingClientRect().width <= 0) {
-    // A zero-width element is not a reliable overflow signal; let the caller
-    // keep the unclamped source until layout becomes measurable.
-    return null;
-  }
-
-  if (mode === "multi-line") {
-    return element.scrollHeight > element.clientHeight + 0.5;
-  }
-
-  return element.scrollWidth > element.clientWidth + 0.5;
-}
-
 export const LineClamp = defineComponent({
   name: "LineClamp",
   inheritAttrs: false,
@@ -166,29 +81,6 @@ export const LineClamp = defineComponent({
     const hasLimit = computed(() => lineLimit.value !== undefined || props.maxHeight !== undefined);
     const locationRatio = computed(() => normalizeLocationRatio(props.location));
     const preparedText = computed(() => prepareText(props.text, props.boundary));
-    const baseNativeMode = computed<NativeMode | null>(() => {
-      if (
-        expanded.value ||
-        props.maxHeight !== undefined ||
-        locationRatio.value !== 1 ||
-        props.boundary !== "grapheme" ||
-        props.ellipsis !== "…"
-      ) {
-        // Native CSS cannot honor custom boundaries or non-end locations, so
-        // those cases stay on the measured path.
-        return null;
-      }
-
-      if (lineLimit.value === 1) {
-        return "single-line";
-      }
-
-      if (lineLimit.value !== undefined && lineLimit.value > 1 && supportsLineClamp()) {
-        return "multi-line";
-      }
-
-      return null;
-    });
 
     async function applyTextState(nextText: string, nextClamped: boolean): Promise<void> {
       const changed = visibleText.value !== nextText || isClamped.value !== nextClamped;
@@ -248,14 +140,14 @@ export const LineClamp = defineComponent({
           return;
         }
 
-        const nativeMode = pickNativeMode(baseNativeMode.value, afterRef.value !== null);
+        const nativeMode = getNativeMode(afterRef.value !== null);
 
         if (nativeMode) {
           // Browser native clamping is cheaper and more faithful for exact
           // subsets where CSS supports every requested behavior.
           lastTextClamp = null;
           const clampedElement = nativeMode === "multi-line" ? contentElement : textElement;
-          const nextClamped = isNativeClamped(clampedElement, nativeMode);
+          const nextClamped = measureNativeClamped(clampedElement, nativeMode);
           await applyTextState(sourceText, nextClamped ?? false);
           return;
         }
@@ -285,6 +177,18 @@ export const LineClamp = defineComponent({
         await applyTextState(nextResult.text, nextResult.text !== prepared.text);
       },
     });
+
+    function getNativeMode(hasAfterSlot: boolean) {
+      return resolveNativeMode({
+        boundary: props.boundary,
+        ellipsis: props.ellipsis,
+        expanded: expanded.value,
+        hasAfterSlot,
+        lineLimit: lineLimit.value,
+        locationRatio: locationRatio.value,
+        maxHeight: props.maxHeight,
+      });
+    }
 
     watch(
       [
@@ -331,15 +235,13 @@ export const LineClamp = defineComponent({
       const afterSlot = slots.after?.(slotProps);
       const hasBeforeSlot = hasSlotContent(beforeSlot);
       const hasAfterSlot = hasSlotContent(afterSlot);
-      const nativeMode = pickNativeMode(baseNativeMode.value, hasAfterSlot);
+      const nativeMode = getNativeMode(hasAfterSlot);
       const usesNativeTextOverflow = nativeMode === "single-line";
       const needsAccessibleSourceText =
         !nativeMode && visibleText.value !== sourceText && hasLimit.value && !expanded.value;
       // When JS rewrites visible text, keep the full source in the accessibility
       // tree while hiding only the visual replacement from assistive tech.
-      const bodyStyle = usesNativeTextOverflow
-        ? nativeSingleLineBodyStyle
-        : { position: "relative" };
+      const bodyStyle = usesNativeTextOverflow ? nativeBodyStyle : { position: "relative" };
       const shouldRenderFullText =
         nativeMode || expanded.value || visibleText.value.length === 0 || !hasLimit.value;
       const renderedText = shouldRenderFullText ? sourceText : visibleText.value;
@@ -359,12 +261,7 @@ export const LineClamp = defineComponent({
             key: "text",
             ref: textRef,
             "aria-hidden": needsAccessibleSourceText ? "true" : undefined,
-            style: usesNativeTextOverflow
-              ? {
-                  ...nativeSingleLineTextStyle,
-                  textOverflow: "ellipsis",
-                }
-              : undefined,
+            style: usesNativeTextOverflow ? nativeTextStyle : undefined,
           },
           renderedText,
         ),
@@ -385,7 +282,7 @@ export const LineClamp = defineComponent({
           {
             "data-part": "content",
             ref: contentRef,
-            style: getContentStyle(nativeMode, lineLimit.value),
+            style: getNativeContentStyle(nativeMode, lineLimit.value),
           },
           [
             hasBeforeSlot
@@ -394,7 +291,7 @@ export const LineClamp = defineComponent({
                   {
                     "data-part": "before",
                     ref: beforeRef,
-                    style: usesNativeTextOverflow ? nativeSingleLineSlotStyle : slotStyle,
+                    style: usesNativeTextOverflow ? nativeSlotStyle : slotStyle,
                   },
                   beforeSlot,
                 )
@@ -414,7 +311,7 @@ export const LineClamp = defineComponent({
                   {
                     "data-part": "after",
                     ref: afterRef,
-                    style: usesNativeTextOverflow ? nativeSingleLineSlotStyle : slotStyle,
+                    style: usesNativeTextOverflow ? nativeSlotStyle : slotStyle,
                   },
                   afterSlot,
                 )

--- a/packages/vue-clamp/src/LineClamp.ts
+++ b/packages/vue-clamp/src/LineClamp.ts
@@ -11,17 +11,13 @@ import {
   maxLinesProp,
 } from "./props.ts";
 import { hasSlotContent } from "./slot.ts";
-import {
-  canUseNativeClamp,
-  clampTextToLayout,
-  isNativeClamped,
-  normalizeLocationRatio,
-  prepareText,
-} from "./text.ts";
+import { clampTextToLayout, normalizeLocationRatio, prepareText } from "./text.ts";
 
 import type { CSSProperties, VNodeChild } from "vue";
 import type { LineClampExposed, LineClampSlotProps } from "./types.ts";
 import type { TextClampResult } from "./text.ts";
+
+type NativeMode = "single-line" | "multi-line";
 
 // Slot wrappers are inline-flex so before/after controls participate in the same
 // line box as text while staying atomic during measurement.
@@ -33,7 +29,9 @@ const slotStyle: CSSProperties = {
   verticalAlign: "baseline",
 };
 
-const nativeContentStyle: CSSProperties = {
+let lineClampSupport: boolean | null = null;
+
+const nativeSingleLineContentStyle: CSSProperties = {
   alignItems: "baseline",
   display: "inline-flex",
   maxWidth: "100%",
@@ -41,22 +39,49 @@ const nativeContentStyle: CSSProperties = {
   width: "100%",
 };
 
-// The native path is intentionally narrow: it is only used when browser
-// text-overflow semantics exactly match the public props.
-const nativeTextStyle: CSSProperties = {
+function makeMultilineStyle(lineLimit: number): CSSProperties {
+  return {
+    display: "-webkit-box",
+    lineClamp: String(lineLimit),
+    maxWidth: "100%",
+    overflow: "hidden",
+    verticalAlign: "baseline",
+    WebkitBoxOrient: "vertical",
+    WebkitLineClamp: String(lineLimit),
+  };
+}
+
+function getContentStyle(
+  mode: NativeMode | null,
+  lineLimit: number | undefined,
+): CSSProperties | undefined {
+  if (mode === "single-line") {
+    return nativeSingleLineContentStyle;
+  }
+
+  if (mode === "multi-line" && lineLimit !== undefined) {
+    return makeMultilineStyle(lineLimit);
+  }
+
+  return undefined;
+}
+
+// Native paths are intentionally narrow: they are only used when browser CSS
+// semantics exactly match the public props.
+const nativeSingleLineTextStyle: CSSProperties = {
   display: "block",
   overflow: "hidden",
   overflowWrap: "normal",
   whiteSpace: "nowrap",
 };
 
-const nativeTextContainerStyle: CSSProperties = {
+const nativeSingleLineBodyStyle: CSSProperties = {
   display: "block",
   flex: "1 1 auto",
   minWidth: "0",
 };
 
-const nativeSlotStyle: CSSProperties = {
+const nativeSingleLineSlotStyle: CSSProperties = {
   ...slotStyle,
   flex: "none",
 };
@@ -89,6 +114,44 @@ const emitsDef = {
   clampchange: (value: boolean) => typeof value === "boolean",
 };
 
+// Native multi-line line-clamp cannot reserve trailing after-slot content.
+// The single-line text-overflow path keeps slots in a flex row, so it remains eligible.
+function pickNativeMode(mode: NativeMode | null, hasAfterSlot: boolean): NativeMode | null {
+  if (mode === "multi-line" && hasAfterSlot) {
+    return null;
+  }
+
+  return mode;
+}
+
+function supportsLineClamp(): boolean {
+  if (lineClampSupport !== null) {
+    return lineClampSupport;
+  }
+
+  if (typeof CSS === "undefined" || typeof CSS.supports !== "function") {
+    return false;
+  }
+
+  lineClampSupport = CSS.supports("-webkit-line-clamp", "2") || CSS.supports("line-clamp", "2");
+
+  return lineClampSupport;
+}
+
+function isNativeClamped(element: HTMLElement, mode: NativeMode): boolean | null {
+  if (element.clientWidth <= 0 || element.getBoundingClientRect().width <= 0) {
+    // A zero-width element is not a reliable overflow signal; let the caller
+    // keep the unclamped source until layout becomes measurable.
+    return null;
+  }
+
+  if (mode === "multi-line") {
+    return element.scrollHeight > element.clientHeight + 0.5;
+  }
+
+  return element.scrollWidth > element.clientWidth + 0.5;
+}
+
 export const LineClamp = defineComponent({
   name: "LineClamp",
   inheritAttrs: false,
@@ -103,16 +166,29 @@ export const LineClamp = defineComponent({
     const hasLimit = computed(() => lineLimit.value !== undefined || props.maxHeight !== undefined);
     const locationRatio = computed(() => normalizeLocationRatio(props.location));
     const preparedText = computed(() => prepareText(props.text, props.boundary));
-    const nativeOverflowMode = computed(() =>
-      canUseNativeClamp(
-        expanded.value,
-        lineLimit.value,
-        props.maxHeight,
-        locationRatio.value,
-        props.ellipsis,
-        props.boundary,
-      ),
-    );
+    const baseNativeMode = computed<NativeMode | null>(() => {
+      if (
+        expanded.value ||
+        props.maxHeight !== undefined ||
+        locationRatio.value !== 1 ||
+        props.boundary !== "grapheme" ||
+        props.ellipsis !== "…"
+      ) {
+        // Native CSS cannot honor custom boundaries or non-end locations, so
+        // those cases stay on the measured path.
+        return null;
+      }
+
+      if (lineLimit.value === 1) {
+        return "single-line";
+      }
+
+      if (lineLimit.value !== undefined && lineLimit.value > 1 && supportsLineClamp()) {
+        return "multi-line";
+      }
+
+      return null;
+    });
 
     async function applyTextState(nextText: string, nextClamped: boolean): Promise<void> {
       const changed = visibleText.value !== nextText || isClamped.value !== nextClamped;
@@ -152,7 +228,7 @@ export const LineClamp = defineComponent({
       onClampedChange: (value) => {
         emit("clampchange", value);
       },
-      recompute: async ({ expanded }): Promise<void> => {
+      recompute: async (expanded): Promise<void> => {
         const { ellipsis, maxHeight, text: sourceText } = props;
         if (expanded.value || sourceText.length === 0 || !hasLimit.value) {
           // Expanded, empty, and unlimited states should expose the source text
@@ -172,28 +248,31 @@ export const LineClamp = defineComponent({
           return;
         }
 
-        if (nativeOverflowMode.value) {
-          // Browser text-overflow is cheaper and more faithful for the one case
-          // where it supports every requested behavior.
+        const nativeMode = pickNativeMode(baseNativeMode.value, afterRef.value !== null);
+
+        if (nativeMode) {
+          // Browser native clamping is cheaper and more faithful for exact
+          // subsets where CSS supports every requested behavior.
           lastTextClamp = null;
-          const nextClamped = isNativeClamped(textElement);
+          const clampedElement = nativeMode === "multi-line" ? contentElement : textElement;
+          const nextClamped = isNativeClamped(clampedElement, nativeMode);
           await applyTextState(sourceText, nextClamped ?? false);
           return;
         }
 
         const prepared = preparedText.value;
         const ratio = locationRatio.value;
-        const nextResult = clampTextToLayout(
-          prepared,
-          rootElement,
-          contentElement,
-          textElement,
-          ratio,
+        const nextResult = clampTextToLayout({
+          content: contentElement,
           ellipsis,
-          lineLimit.value,
+          hint: lastTextClamp,
+          lineLimit: lineLimit.value,
           maxHeight,
-          lastTextClamp,
-        );
+          prepared,
+          ratio,
+          root: rootElement,
+          target: textElement,
+        });
 
         if (nextResult === null) {
           // A zero-width root cannot produce a stable clamp; keep source text
@@ -252,14 +331,17 @@ export const LineClamp = defineComponent({
       const afterSlot = slots.after?.(slotProps);
       const hasBeforeSlot = hasSlotContent(beforeSlot);
       const hasAfterSlot = hasSlotContent(afterSlot);
-      const nativeOverflow = nativeOverflowMode.value;
+      const nativeMode = pickNativeMode(baseNativeMode.value, hasAfterSlot);
+      const usesNativeTextOverflow = nativeMode === "single-line";
       const needsAccessibleSourceText =
-        !nativeOverflow && visibleText.value !== sourceText && hasLimit.value && !expanded.value;
+        !nativeMode && visibleText.value !== sourceText && hasLimit.value && !expanded.value;
       // When JS rewrites visible text, keep the full source in the accessibility
       // tree while hiding only the visual replacement from assistive tech.
-      const bodyStyle = nativeOverflow ? nativeTextContainerStyle : { position: "relative" };
+      const bodyStyle = usesNativeTextOverflow
+        ? nativeSingleLineBodyStyle
+        : { position: "relative" };
       const shouldRenderFullText =
-        nativeOverflow || expanded.value || visibleText.value.length === 0 || !hasLimit.value;
+        nativeMode || expanded.value || visibleText.value.length === 0 || !hasLimit.value;
       const renderedText = shouldRenderFullText ? sourceText : visibleText.value;
       const bodyChildren: VNodeChild[] = [
         needsAccessibleSourceText
@@ -277,10 +359,10 @@ export const LineClamp = defineComponent({
             key: "text",
             ref: textRef,
             "aria-hidden": needsAccessibleSourceText ? "true" : undefined,
-            style: nativeOverflow
+            style: usesNativeTextOverflow
               ? {
-                  ...nativeTextStyle,
-                  textOverflow: nativeOverflow,
+                  ...nativeSingleLineTextStyle,
+                  textOverflow: "ellipsis",
                 }
               : undefined,
           },
@@ -303,7 +385,7 @@ export const LineClamp = defineComponent({
           {
             "data-part": "content",
             ref: contentRef,
-            style: nativeOverflow ? nativeContentStyle : undefined,
+            style: getContentStyle(nativeMode, lineLimit.value),
           },
           [
             hasBeforeSlot
@@ -312,7 +394,7 @@ export const LineClamp = defineComponent({
                   {
                     "data-part": "before",
                     ref: beforeRef,
-                    style: nativeOverflow ? nativeSlotStyle : slotStyle,
+                    style: usesNativeTextOverflow ? nativeSingleLineSlotStyle : slotStyle,
                   },
                   beforeSlot,
                 )
@@ -332,7 +414,7 @@ export const LineClamp = defineComponent({
                   {
                     "data-part": "after",
                     ref: afterRef,
-                    style: nativeOverflow ? nativeSlotStyle : slotStyle,
+                    style: usesNativeTextOverflow ? nativeSingleLineSlotStyle : slotStyle,
                   },
                   afterSlot,
                 )

--- a/packages/vue-clamp/src/RichLineClamp.ts
+++ b/packages/vue-clamp/src/RichLineClamp.ts
@@ -9,11 +9,11 @@ import {
   maxHeightProp,
   maxLinesProp,
 } from "./props.ts";
-import { clampRichTextToLayout, patchRichTextToDecision, prepareRichText } from "./rich.ts";
+import { clampRich, patchRich, prepareRich } from "./rich.ts";
 import { hasSlotContent } from "./slot.ts";
 
 import type { CSSProperties } from "vue";
-import type { PreparedRichText, RichClampDecision } from "./rich.ts";
+import type { PreparedRich, RichState } from "./rich.ts";
 import type { RichLineClampExposed, RichLineClampSlotProps } from "./types.ts";
 
 const slotStyle: CSSProperties = {
@@ -62,7 +62,7 @@ const emitsDef = {
   clampchange: (value: boolean) => typeof value === "boolean",
 };
 
-function createProbeElements(): ProbeElements {
+function createProbe(): ProbeElements {
   const content = document.createElement("span");
   const body = document.createElement("span");
 
@@ -83,40 +83,34 @@ export const RichLineClamp = defineComponent({
 
     const lineLimit = computed(() => normalizeLineLimit(props.maxLines));
     const hasLimit = computed(() => lineLimit.value !== undefined || props.maxHeight !== undefined);
-    const preparedHtml = computed(() => prepareRichText(props.html, props.boundary));
-    // The visible tree and hidden probe advance independently: visibleDecision
-    // patches user-facing DOM, while probeDecision keeps measurement patches
-    // cheap across repeated reclamps.
-    let visibleDecision: RichClampDecision | null = null;
-    let probeDecision: RichClampDecision | null = null;
+    const preparedHtml = computed(() => prepareRich(props.html, props.boundary));
+    // The visible tree and hidden probe advance independently: visibleState
+    // patches user-facing DOM, while probeState keeps measurement patches cheap
+    // across repeated reclamps.
+    let visibleState: RichState | null = null;
+    let probeState: RichState | null = null;
     let probeElements: ProbeElements | null = null;
-    let probeDecisionWidth: number | null = null;
+    let probeStateWidth: number | null = null;
 
-    function resetDecisions(): void {
-      visibleDecision = null;
-      probeDecision = null;
-      probeDecisionWidth = null;
+    function resetStates(): void {
+      visibleState = null;
+      probeState = null;
+      probeStateWidth = null;
     }
 
-    function patchVisible(prepared: PreparedRichText, decision: RichClampDecision): void {
+    function patchVisible(prepared: PreparedRich, state: RichState): void {
       const bodyElement = bodyRef.value;
       if (!bodyElement) {
-        // If Vue has not mounted the target body, discard decisions rather than
+        // If Vue has not mounted the target body, discard states rather than
         // applying future patches against an unknown DOM state.
-        resetDecisions();
+        resetStates();
         return;
       }
 
-      visibleDecision = patchRichTextToDecision(
-        prepared,
-        bodyElement,
-        visibleDecision,
-        decision,
-        props.ellipsis,
-      );
+      visibleState = patchRich(prepared, bodyElement, visibleState, state, props.ellipsis);
     }
 
-    async function applyState(nextClamped: boolean, nextFallback: boolean): Promise<void> {
+    async function applyStatus(nextClamped: boolean, nextFallback: boolean): Promise<void> {
       const changed = isClamped.value !== nextClamped || isFallback.value !== nextFallback;
 
       isClamped.value = nextClamped;
@@ -137,10 +131,10 @@ export const RichLineClamp = defineComponent({
         // are restored consistently with normal clamp commits.
         patchVisible(prepared, { kind: "full" });
       } else {
-        resetDecisions();
+        resetStates();
       }
 
-      await applyState(false, false);
+      await applyStatus(false, false);
     }
 
     function prepareProbe(): {
@@ -155,7 +149,7 @@ export const RichLineClamp = defineComponent({
         return null;
       }
 
-      const elements = (probeElements ??= createProbeElements());
+      const elements = (probeElements ??= createProbe());
       const maxHeight = cssLength(props.maxHeight);
       const width = rootElement.getBoundingClientRect().width;
 
@@ -209,7 +203,7 @@ export const RichLineClamp = defineComponent({
       onClampedChange: (value) => {
         emit("clampchange", value);
       },
-      recompute: async ({ expanded }): Promise<void> => {
+      recompute: async (expanded): Promise<void> => {
         const { ellipsis, html: sourceHtml, maxHeight } = props;
         if (expanded.value || sourceHtml.length === 0 || !hasLimit.value) {
           // Expanded, empty, and unlimited states should leave the trusted HTML
@@ -233,37 +227,35 @@ export const RichLineClamp = defineComponent({
           return;
         }
 
-        const searchDecision =
-          probeDecisionWidth === null ||
-          Math.abs(probe.width - probeDecisionWidth) <= warmSearchWidthDelta
-            ? probeDecision
+        const searchHint =
+          probeStateWidth === null ||
+          Math.abs(probe.width - probeStateWidth) <= warmSearchWidthDelta
+            ? probeState
             : null;
         // Search hints help nearby resizes but can cost more on large jumps. The
-        // current probe decision is still passed separately so patching remains
+        // current probe state is still passed separately so patching remains
         // correct even when the search starts cold.
-        const nextState = clampRichTextToLayout(
-          prepared,
-          probe.root,
-          probe.content,
-          probe.body,
-          probeDecision,
-          searchDecision,
+        const result = clampRich({
           ellipsis,
-          lineLimit.value,
+          from: probeState,
+          hint: searchHint,
+          lineLimit: lineLimit.value,
           maxHeight,
-        );
-        probeDecision = nextState.decision;
-        probeDecisionWidth = probe.width;
+          prepared,
+          probe,
+        });
+        probeState = result.state;
+        probeStateWidth = probe.width;
 
-        if (!nextState.decision) {
+        if (!result.state) {
           // A zero-width probe should not replace visible content with a guessed
           // rich fragment.
           await resetClamp();
           return;
         }
 
-        patchVisible(prepared, nextState.decision);
-        await applyState(nextState.decision.kind === "clamped", nextState.fallback);
+        patchVisible(prepared, result.state);
+        await applyStatus(result.state.kind === "clamped", result.fallback);
       },
     });
 
@@ -276,9 +268,9 @@ export const RichLineClamp = defineComponent({
         () => props.boundary,
       ],
       () => {
-        // HTML and clamp semantics change the structural decision space, so both
+        // HTML and clamp semantics change the structural state space, so both
         // visible and probe patch cursors must restart.
-        resetDecisions();
+        resetStates();
         isFallback.value = false;
         requestRecompute();
       },

--- a/packages/vue-clamp/src/WrapClamp.ts
+++ b/packages/vue-clamp/src/WrapClamp.ts
@@ -479,11 +479,3 @@ export const WrapClamp = defineComponent({
     };
   },
 });
-
-export type {
-  WrapClampExposed,
-  WrapClampItemKey,
-  WrapClampItemSlotProps,
-  WrapClampProps,
-  WrapClampSlotProps,
-} from "./types.ts";

--- a/packages/vue-clamp/src/layout.ts
+++ b/packages/vue-clamp/src/layout.ts
@@ -67,6 +67,15 @@ export function listenForFontLoads(onLoad: () => void): () => void {
   };
 }
 
+type LineBox = {
+  bottom: number;
+  top: number;
+};
+
+function sameLineBox(line: LineBox, rect: DOMRect): boolean {
+  return Math.abs(line.top - rect.top) <= 0.5 && Math.abs(line.bottom - rect.bottom) <= 0.5;
+}
+
 // All DOM clamp implementations use this fit predicate so line counting and
 // max-height clipping agree. It short-circuits as soon as a candidate is known
 // not to fit because this runs inside search loops.
@@ -82,7 +91,7 @@ export function fitsContent(
   }
 
   const rects = contentElement.getClientRects();
-  const lines: string[] = [];
+  const lines: LineBox[] = [];
   let visibleTop = 0;
   let visibleBottom = 0;
   let measuredVisibleBounds = false;
@@ -109,11 +118,13 @@ export function fitsContent(
     }
 
     if (lineLimit !== undefined) {
-      const line = `${rect.top}/${rect.bottom}`;
-      if (!lines.includes(line)) {
+      if (!lines.some((line) => sameLineBox(line, rect))) {
         // Browser rects are the source of truth for wrapped lines; grouping by
         // vertical bounds handles inline content that splits into many boxes.
-        lines.push(line);
+        lines.push({
+          bottom: rect.bottom,
+          top: rect.top,
+        });
 
         if (lines.length > lineLimit) {
           return false;

--- a/packages/vue-clamp/src/multiline.ts
+++ b/packages/vue-clamp/src/multiline.ts
@@ -11,24 +11,24 @@ type FrameRefs = {
   afterRef: Ref<HTMLElement | null>;
 };
 
-type ClampState = FrameRefs & {
+type ShellState = FrameRefs & {
   expanded: Ref<boolean>;
   isClamped: Ref<boolean>;
 };
 
-type ClampShellOptions = {
+type ShellOptions = {
   getExpanded: () => boolean;
   onExpandedChange: (value: boolean) => void;
   onClampedChange: (value: boolean) => void;
-  recompute: (state: ClampState) => Promise<void>;
+  recompute: (expanded: Ref<boolean>) => Promise<void>;
 };
 
 // LineClamp and RichLineClamp have different clamp engines but the same shell:
 // controlled expansion, slot/root refs, invalidation sources, and event timing.
 // Keeping that shell here avoids two subtly divergent lifecycle implementations.
-export function useMultilineClamp(options: ClampShellOptions) {
+export function useMultilineClamp(options: ShellOptions) {
   const { getExpanded, onExpandedChange, onClampedChange, recompute } = options;
-  const state: ClampState = {
+  const state: ShellState = {
     rootRef: ref<HTMLElement | null>(null),
     contentRef: ref<HTMLElement | null>(null),
     beforeRef: ref<HTMLElement | null>(null),
@@ -67,7 +67,7 @@ export function useMultilineClamp(options: ClampShellOptions) {
   }
 
   const requestRecompute = createCoalescingRunner(async () => {
-    await recompute(state);
+    await recompute(state.expanded);
     lastLayoutSignature = layoutSignature();
   });
 

--- a/packages/vue-clamp/src/native.ts
+++ b/packages/vue-clamp/src/native.ts
@@ -1,0 +1,120 @@
+import type { CSSProperties } from "vue";
+import type { ClampBoundary } from "./types.ts";
+
+export type NativeClampMode = "single-line" | "multi-line";
+
+type NativeModeInput = {
+  boundary: ClampBoundary;
+  ellipsis: string;
+  expanded: boolean;
+  hasAfterSlot: boolean;
+  lineLimit: number | undefined;
+  locationRatio: number;
+  maxHeight: number | string | undefined;
+};
+
+let supportsMultilineClamp: boolean | null = null;
+
+export const nativeBodyStyle: CSSProperties = {
+  display: "block",
+  flex: "1 1 auto",
+  minWidth: "0",
+};
+
+export const nativeTextStyle: CSSProperties = {
+  display: "block",
+  overflow: "hidden",
+  overflowWrap: "normal",
+  textOverflow: "ellipsis",
+  whiteSpace: "nowrap",
+};
+
+const nativeSingleLineContentStyle: CSSProperties = {
+  alignItems: "baseline",
+  display: "inline-flex",
+  maxWidth: "100%",
+  verticalAlign: "baseline",
+  width: "100%",
+};
+
+function hasMultilineClamp(): boolean {
+  if (supportsMultilineClamp !== null) {
+    return supportsMultilineClamp;
+  }
+
+  supportsMultilineClamp =
+    typeof CSS !== "undefined" &&
+    typeof CSS.supports === "function" &&
+    (CSS.supports("-webkit-line-clamp", "2") || CSS.supports("line-clamp", "2"));
+
+  return supportsMultilineClamp;
+}
+
+export function resolveNativeMode({
+  boundary,
+  ellipsis,
+  expanded,
+  hasAfterSlot,
+  lineLimit,
+  locationRatio,
+  maxHeight,
+}: NativeModeInput): NativeClampMode | null {
+  // Native CSS only matches end/grapheme/default-ellipsis text. Other props need
+  // the measured path so the public API keeps the same semantics.
+  if (
+    expanded ||
+    maxHeight !== undefined ||
+    locationRatio !== 1 ||
+    boundary !== "grapheme" ||
+    ellipsis !== "…"
+  ) {
+    return null;
+  }
+
+  if (lineLimit === 1) {
+    return "single-line";
+  }
+
+  // Multiline line-clamp cannot reserve suffix slot space. The single-line
+  // text-overflow path can because slots are fixed flex siblings.
+  if (lineLimit !== undefined && lineLimit > 1 && !hasAfterSlot && hasMultilineClamp()) {
+    return "multi-line";
+  }
+
+  return null;
+}
+
+export function getNativeContentStyle(
+  mode: NativeClampMode | null,
+  lineLimit: number | undefined,
+): CSSProperties | undefined {
+  if (mode === "single-line") {
+    return nativeSingleLineContentStyle;
+  }
+
+  if (mode !== "multi-line" || lineLimit === undefined) {
+    return undefined;
+  }
+
+  return {
+    display: "-webkit-box",
+    lineClamp: String(lineLimit),
+    maxWidth: "100%",
+    overflow: "hidden",
+    verticalAlign: "baseline",
+    WebkitBoxOrient: "vertical",
+    WebkitLineClamp: String(lineLimit),
+  };
+}
+
+export function measureNativeClamped(element: HTMLElement, mode: NativeClampMode): boolean | null {
+  if (element.clientWidth <= 0 || element.getBoundingClientRect().width <= 0) {
+    return null;
+  }
+
+  if (mode === "multi-line") {
+    return element.scrollHeight > element.clientHeight + 0.5;
+  }
+
+  return element.scrollWidth > element.clientWidth + 0.5;
+}

--- a/packages/vue-clamp/src/rich.ts
+++ b/packages/vue-clamp/src/rich.ts
@@ -5,7 +5,7 @@ import { prepareText } from "./text.ts";
 import type { ClampBoundary } from "./types.ts";
 
 // Rich clamping is structural rather than string-based. We parse once, measure
-// candidate DOM fragments, and patch decisions back into the visible/probe DOM.
+// candidate DOM fragments, and patch structural states back into visible/probe DOM.
 type BoundaryPoint = {
   path: readonly number[];
   offset: number;
@@ -14,8 +14,8 @@ type BoundaryPoint = {
 type PreparedTextNode = {
   kind: "text";
   endPoint: BoundaryPoint;
-  textCuts: BoundaryPoint[];
-  fallbackTextCuts?: BoundaryPoint[];
+  textCuts: readonly BoundaryPoint[];
+  fallbackTextCuts?: readonly BoundaryPoint[];
 };
 
 type PreparedElementNode = {
@@ -23,7 +23,7 @@ type PreparedElementNode = {
   pathKey: string;
   isBreak: boolean;
   endPoint: BoundaryPoint;
-  children: PreparedRichNode[];
+  children: readonly PreparedRichNode[];
 };
 
 type PreparedRichNode = PreparedTextNode | PreparedElementNode;
@@ -32,22 +32,22 @@ type LogicalRun =
   | {
       kind: "text";
       endPoint: BoundaryPoint;
-      textCuts: BoundaryPoint[];
-      fallbackTextCuts?: BoundaryPoint[];
+      textCuts: readonly BoundaryPoint[];
+      fallbackTextCuts?: readonly BoundaryPoint[];
     }
   | {
       kind: "atomic";
       endPoint: BoundaryPoint;
     };
 
-export type PreparedRichText = {
+export type PreparedRich = {
   root: HTMLElement;
-  nodes: PreparedRichNode[];
+  nodes: readonly PreparedRichNode[];
 };
 
-// Decisions are kept as structural points so width-only reclamps can patch from
-// the previous DOM state without serializing and reparsing HTML.
-export type RichClampDecision =
+// States are kept as structural points so width-only reclamps can patch from the
+// previous DOM state without serializing and reparsing HTML.
+export type RichState =
   | {
       kind: "full";
     }
@@ -66,9 +66,25 @@ type PatchAnchor = {
   startIndex: number;
 };
 
-type RichClampResult = {
-  decision: RichClampDecision | null;
+type ClampResult = {
   fallback: boolean;
+  state: RichState | null;
+};
+
+type Probe = {
+  body: HTMLElement;
+  content: HTMLElement;
+  root: HTMLElement;
+};
+
+type ClampOptions = {
+  ellipsis: string;
+  from: RichState | null;
+  hint: RichState | null;
+  lineLimit: number | undefined;
+  maxHeight: number | string | undefined;
+  prepared: PreparedRich;
+  probe: Probe;
 };
 
 const ROOT_PATH: readonly number[] = [];
@@ -521,8 +537,8 @@ function fullEndPoint(root: HTMLElement): BoundaryPoint {
   };
 }
 
-function endPointForDecision(root: HTMLElement, decision: RichClampDecision): BoundaryPoint {
-  return decision.kind === "full" ? fullEndPoint(root) : decision.point;
+function pointForState(root: HTMLElement, state: RichState): BoundaryPoint {
+  return state.kind === "full" ? fullEndPoint(root) : state.point;
 }
 
 function resolvePath(root: Node, path: readonly number[]): Node | null {
@@ -604,7 +620,7 @@ function sameBoundaryPoint(left: BoundaryPoint, right: BoundaryPoint): boolean {
   return left.offset === right.offset && pathKey(left.path) === pathKey(right.path);
 }
 
-function sameDecision(left: RichClampDecision | null, right: RichClampDecision): boolean {
+function sameState(left: RichState | null, right: RichState): boolean {
   if (!left || left.kind !== right.kind) {
     return false;
   }
@@ -622,56 +638,54 @@ function removeChildrenFrom(container: Node, startIndex: number): void {
   }
 }
 
-export function patchRichTextToDecision(
-  prepared: PreparedRichText,
-  targetElement: HTMLElement,
-  currentDecision: RichClampDecision | null,
-  nextDecision: RichClampDecision,
+export function patchRich(
+  prepared: PreparedRich,
+  target: HTMLElement,
+  from: RichState | null,
+  to: RichState,
   ellipsis: string,
   imageSource?: string,
-): RichClampDecision {
-  if (sameDecision(currentDecision, nextDecision)) {
+): RichState {
+  if (sameState(from, to)) {
     // Avoid touching DOM when the search probes the same structural point again.
-    return nextDecision;
+    return to;
   }
 
   const { root } = prepared;
-  const currentPoint = currentDecision
-    ? endPointForDecision(root, currentDecision)
-    : ROOT_START_POINT;
-  const nextPoint = endPointForDecision(root, nextDecision);
+  const currentPoint = from ? pointForState(root, from) : ROOT_START_POINT;
+  const nextPoint = pointForState(root, to);
   const anchor = patchAnchorFor(root, currentPoint, nextPoint);
   const fragment = clonePatchFromAnchor(root, anchor, nextPoint, imageSource);
 
-  if (currentDecision?.kind === "clamped") {
+  if (from?.kind === "clamped") {
     // The root-level ellipsis is outside the structural source tree, so remove it
     // before calculating the next source-derived suffix.
-    removeRootEllipsis(targetElement, ellipsis);
+    removeRootEllipsis(target, ellipsis);
   }
 
-  const liveAnchor = resolvePatchAnchor(targetElement, anchor.path);
+  const liveAnchor = resolvePatchAnchor(target, anchor.path);
 
   removeChildrenFrom(liveAnchor, anchor.startIndex);
 
-  if (nextDecision.kind === "clamped") {
+  if (to.kind === "clamped") {
     trimTrailingWhitespace(fragment);
   }
 
   liveAnchor.appendChild(fragment);
 
-  if (nextDecision.kind === "clamped") {
+  if (to.kind === "clamped") {
     // Ellipsis is deliberately appended to the rich body root, not inside the
     // innermost inline element, so source markup remains structurally intact.
-    appendEllipsis(targetElement, ellipsis);
+    appendEllipsis(target, ellipsis);
   }
 
-  return nextDecision;
+  return to;
 }
 
-export function prepareRichText(
+export function prepareRich(
   html: string,
   boundary: ClampBoundary = "grapheme",
-): PreparedRichText | null {
+): PreparedRich | null {
   if (typeof DOMParser === "undefined") {
     return null;
   }
@@ -695,21 +709,18 @@ function boundaryPointIndex(points: readonly BoundaryPoint[], point: BoundaryPoi
   return null;
 }
 
-function runIndexHintForDecision(
-  runs: readonly LogicalRun[],
-  decision: RichClampDecision | null,
-): number | null {
-  if (!decision) {
+function runHintForState(runs: readonly LogicalRun[], state: RichState | null): number | null {
+  if (!state) {
     return null;
   }
 
-  if (decision.kind === "full") {
+  if (state.kind === "full") {
     // Full content corresponds to the last run end and is a good warm-start
     // point before a shrink.
     return runs.length - 1;
   }
 
-  const { point } = decision;
+  const { point } = state;
 
   for (let index = 0; index < runs.length; index += 1) {
     const run = runs[index]!;
@@ -732,41 +743,33 @@ function runIndexHintForDecision(
   return null;
 }
 
-export function clampRichTextToLayout(
-  prepared: PreparedRichText,
-  rootElement: HTMLElement,
-  contentElement: HTMLElement,
-  richElement: HTMLElement,
-  currentDecision: RichClampDecision | null,
-  searchDecision: RichClampDecision | null,
-  ellipsis: string,
-  lineLimit: number | undefined,
-  maxHeight: number | string | undefined,
-): RichClampResult {
+export function clampRich({
+  ellipsis,
+  from,
+  hint,
+  lineLimit,
+  maxHeight,
+  prepared,
+  probe,
+}: ClampOptions): ClampResult {
   const { nodes } = prepared;
+  const { body, content, root } = probe;
 
-  if (rootElement.getBoundingClientRect().width <= 0) {
-    // An unmeasurable probe cannot produce a trustworthy structural decision.
+  if (root.getBoundingClientRect().width <= 0) {
+    // An unmeasurable probe cannot produce a trustworthy structural state.
     return {
-      decision: null,
+      state: null,
       fallback: false,
     };
   }
 
-  let decision = patchRichTextToDecision(
-    prepared,
-    richElement,
-    currentDecision,
-    { kind: "full" },
-    ellipsis,
-    PROBE_IMAGE_SRC,
-  );
+  let state = patchRich(prepared, body, from, { kind: "full" }, ellipsis, PROBE_IMAGE_SRC);
 
   function applyCandidate(point: BoundaryPoint): void {
-    decision = patchRichTextToDecision(
+    state = patchRich(
       prepared,
-      richElement,
-      decision,
+      body,
+      state,
       {
         kind: "clamped",
         point,
@@ -778,39 +781,39 @@ export function clampRichTextToLayout(
 
   function fitsCandidate(endPoint: BoundaryPoint): boolean {
     applyCandidate(endPoint);
-    return fitsContent(rootElement, contentElement, lineLimit, maxHeight);
+    return fitsContent(root, content, lineLimit, maxHeight);
   }
 
-  const atomicPaths = inspectLayout(richElement);
-  if (!atomicPaths) {
+  const layout = inspectLayout(body);
+  if (!layout) {
     // Unsupported inline layout falls back to the original HTML instead of
     // risking a structurally valid but visually wrong clamp.
     return {
-      decision,
+      state,
       fallback: true,
     };
   }
 
-  if (fitsContent(rootElement, contentElement, lineLimit, maxHeight)) {
+  if (fitsContent(root, content, lineLimit, maxHeight)) {
     // The full rich tree fits; exit before logical-run construction because no
     // searchable candidate is needed.
     return {
-      decision,
+      state,
       fallback: false,
     };
   }
 
-  const runs = buildLogicalRuns(nodes, atomicPaths);
+  const runs = buildLogicalRuns(nodes, layout);
   if (runs.length === 0) {
     // Rich content can be all comments/empty text; in that case the full patched
     // state is already the only meaningful answer.
     return {
-      decision,
+      state,
       fallback: false,
     };
   }
 
-  const coarseHint = runIndexHintForDecision(runs, searchDecision);
+  const coarseHint = runHintForState(runs, hint);
   // Coarse search skips over complete logical runs first so refinement only has
   // to slice the one text run that crosses the fit boundary.
   const coarseIndex = findLastFittingIndex(
@@ -826,15 +829,13 @@ export function clampRichTextToLayout(
     // coarse point.
     applyCandidate(coarsePoint);
     return {
-      decision,
+      state,
       fallback: false,
     };
   }
 
   const fineHint =
-    searchDecision?.kind === "clamped"
-      ? boundaryPointIndex(nextRun.textCuts, searchDecision.point)
-      : null;
+    hint?.kind === "clamped" ? boundaryPointIndex(nextRun.textCuts, hint.point) : null;
   // Fine search is limited to text cuts inside the first overflowing text run.
   const fineIndex = findLastFittingIndex(
     nextRun.textCuts.length,
@@ -847,9 +848,7 @@ export function clampRichTextToLayout(
     // Word boundary mode retries with grapheme cuts only when no whole-word cut
     // in the overflowing run can fit.
     const fallbackHint =
-      searchDecision?.kind === "clamped"
-        ? boundaryPointIndex(nextRun.fallbackTextCuts, searchDecision.point)
-        : null;
+      hint?.kind === "clamped" ? boundaryPointIndex(nextRun.fallbackTextCuts, hint.point) : null;
     const fallbackIndex = findLastFittingIndex(
       nextRun.fallbackTextCuts.length,
       (index) => fitsCandidate(nextRun.fallbackTextCuts![index]!),
@@ -860,7 +859,7 @@ export function clampRichTextToLayout(
 
   applyCandidate(finePoint);
   return {
-    decision,
+    state,
     fallback: false,
   };
 }

--- a/packages/vue-clamp/src/rich.ts
+++ b/packages/vue-clamp/src/rich.ts
@@ -819,7 +819,7 @@ export function clampRich({
   const coarseIndex = findLastFittingIndex(
     runs.length,
     (index) => fitsCandidate(runs[index]!.endPoint),
-    coarseHint === null ? null : { index: coarseHint },
+    coarseHint,
   );
   const coarsePoint = coarseIndex >= 0 ? runs[coarseIndex]!.endPoint : ROOT_START_POINT;
   const nextRun = runs[coarseIndex + 1];
@@ -840,7 +840,7 @@ export function clampRich({
   const fineIndex = findLastFittingIndex(
     nextRun.textCuts.length,
     (index) => fitsCandidate(nextRun.textCuts[index]!),
-    fineHint === null ? null : { index: fineHint },
+    fineHint,
   );
   let finePoint = fineIndex >= 0 ? nextRun.textCuts[fineIndex]! : coarsePoint;
 
@@ -852,7 +852,7 @@ export function clampRich({
     const fallbackIndex = findLastFittingIndex(
       nextRun.fallbackTextCuts.length,
       (index) => fitsCandidate(nextRun.fallbackTextCuts![index]!),
-      fallbackHint === null ? null : { index: fallbackHint },
+      fallbackHint,
     );
     finePoint = fallbackIndex >= 0 ? nextRun.fallbackTextCuts[fallbackIndex]! : coarsePoint;
   }

--- a/packages/vue-clamp/src/search.ts
+++ b/packages/vue-clamp/src/search.ts
@@ -1,4 +1,4 @@
-export type LastFitSearchHint = {
+type SearchHint = {
   index: number;
 };
 
@@ -35,7 +35,7 @@ function binarySearchLastFit(
 export function findLastFittingIndex(
   count: number,
   fits: (index: number) => boolean,
-  hint?: LastFitSearchHint | null,
+  hint?: SearchHint | null,
 ): number {
   if (count <= 0) {
     return -1;

--- a/packages/vue-clamp/src/search.ts
+++ b/packages/vue-clamp/src/search.ts
@@ -1,7 +1,3 @@
-type SearchHint = {
-  index: number;
-};
-
 // Two local expansion steps capture normal resize deltas while bounding the
 // penalty when a previous answer is far from the new fit boundary.
 const warmExpansionLimit = 2;
@@ -35,7 +31,7 @@ function binarySearchLastFit(
 export function findLastFittingIndex(
   count: number,
   fits: (index: number) => boolean,
-  hint?: SearchHint | null,
+  hint?: number | null,
 ): number {
   if (count <= 0) {
     return -1;
@@ -43,11 +39,11 @@ export function findLastFittingIndex(
 
   const maxIndex = count - 1;
 
-  if (!hint || !Number.isFinite(hint.index)) {
+  if (hint == null || !Number.isFinite(hint)) {
     return binarySearchLastFit(0, maxIndex, fits);
   }
 
-  const start = Math.max(0, Math.min(maxIndex, Math.floor(hint.index)));
+  const start = Math.max(0, Math.min(maxIndex, Math.floor(hint)));
 
   if (fits(start)) {
     // Growing from a fitting hint favors the common case where a container gets

--- a/packages/vue-clamp/src/text.ts
+++ b/packages/vue-clamp/src/text.ts
@@ -198,7 +198,7 @@ export function clampTextToFit({
     findLastFittingIndex(
       Math.max(1, boundaryCount),
       (kept) => fits(displayTextForKeptCount(prepared, ratio, ellipsis, kept, spacing)),
-      hint?.boundaryOffsets === prepared.boundaryOffsets ? { index: hint.kept } : null,
+      hint?.boundaryOffsets === prepared.boundaryOffsets ? hint.kept : null,
     ),
   );
 

--- a/packages/vue-clamp/src/text.ts
+++ b/packages/vue-clamp/src/text.ts
@@ -28,16 +28,9 @@ export interface TextClampResult {
 
 type Spacing = "trim" | "preserve-outer";
 
-type FitController = {
-  apply: (text: string) => void;
-  fits: () => boolean;
-};
-
-type Fit = ((text: string) => boolean) | FitController;
-
 type FitInput = {
   ellipsis: string;
-  fit: Fit;
+  fits: (text: string) => boolean;
   hint?: { boundaryOffsets: readonly number[]; kept: number } | null | undefined;
   prepared: PreparedText;
   ratio: number;
@@ -190,38 +183,13 @@ export function normalizeLocationRatio(location: LineClampLocation): number {
 
 export function clampTextToFit({
   ellipsis,
-  fit,
+  fits,
   hint,
   prepared,
   ratio,
   spacing = "trim",
 }: FitInput): TextClampResult {
   const boundaryCount = prepared.boundaryOffsets.length - 1;
-  let currentCandidate: string | null = null;
-
-  function applyCandidate(text: string): void {
-    if (currentCandidate === text) {
-      return;
-    }
-
-    if (typeof fit === "function") {
-      fit(text);
-    } else {
-      fit.apply(text);
-    }
-
-    currentCandidate = text;
-  }
-
-  function testCandidate(text: string): boolean {
-    if (typeof fit === "function") {
-      currentCandidate = text;
-      return fit(text);
-    }
-
-    applyCandidate(text);
-    return fit.fits();
-  }
 
   // The search helper works over indexes. For text, the index is the number of
   // boundary units kept, with at least the zero-kept ellipsis candidate present.
@@ -229,7 +197,7 @@ export function clampTextToFit({
     0,
     findLastFittingIndex(
       Math.max(1, boundaryCount),
-      (kept) => testCandidate(displayTextForKeptCount(prepared, ratio, ellipsis, kept, spacing)),
+      (kept) => fits(displayTextForKeptCount(prepared, ratio, ellipsis, kept, spacing)),
       hint?.boundaryOffsets === prepared.boundaryOffsets ? { index: hint.kept } : null,
     ),
   );
@@ -239,7 +207,7 @@ export function clampTextToFit({
     // word is wider than the container; retry at grapheme granularity.
     return clampTextToFit({
       ellipsis,
-      fit,
+      fits,
       hint,
       prepared: {
         text: prepared.text,
@@ -253,10 +221,6 @@ export function clampTextToFit({
 
   const text = displayTextForKeptCount(prepared, ratio, ellipsis, best, spacing);
 
-  // Leave the measured DOM on the exact text returned to the caller. Controller
-  // callers can apply without an extra layout read when the search ended on a
-  // neighboring candidate.
-  applyCandidate(text);
   return {
     boundaryOffsets: prepared.boundaryOffsets,
     kept: best,
@@ -290,13 +254,8 @@ export function clampTextToLayout({
     }
   }
 
-  const fit: FitController = {
-    apply: applyText,
-    fits: () => fitsContent(root, content, lineLimit, maxHeight),
-  };
-
   applyText(text);
-  if (fit.fits()) {
+  if (fitsContent(root, content, lineLimit, maxHeight)) {
     // The full source is the cheapest and most correct answer when it fits.
     // Store it as a warm-start hint so later shrink passes begin from full text.
     return {
@@ -306,11 +265,17 @@ export function clampTextToLayout({
     };
   }
 
-  return clampTextToFit({
+  const result = clampTextToFit({
     ellipsis,
-    fit,
+    fits(candidate) {
+      applyText(candidate);
+      return fitsContent(root, content, lineLimit, maxHeight);
+    },
     hint,
     prepared,
     ratio,
   });
+  applyText(result.text);
+
+  return result;
 }

--- a/packages/vue-clamp/src/text.ts
+++ b/packages/vue-clamp/src/text.ts
@@ -26,7 +26,35 @@ export interface TextClampResult {
   text: string;
 }
 
-export type TextClampSpacing = "trim" | "preserve-outer";
+type Spacing = "trim" | "preserve-outer";
+
+type FitController = {
+  apply: (text: string) => void;
+  fits: () => boolean;
+};
+
+type Fit = ((text: string) => boolean) | FitController;
+
+type FitInput = {
+  ellipsis: string;
+  fit: Fit;
+  hint?: { boundaryOffsets: readonly number[]; kept: number } | null | undefined;
+  prepared: PreparedText;
+  ratio: number;
+  spacing?: Spacing;
+};
+
+type LayoutInput = {
+  content: HTMLElement;
+  ellipsis: string;
+  hint?: { boundaryOffsets: readonly number[]; kept: number } | null | undefined;
+  lineLimit: number | undefined;
+  maxHeight: number | string | undefined;
+  prepared: PreparedText;
+  ratio: number;
+  root: HTMLElement;
+  target: HTMLElement;
+};
 
 function isAsciiSafe(text: string): boolean {
   for (let index = 0; index < text.length; index += 1) {
@@ -39,8 +67,8 @@ function isAsciiSafe(text: string): boolean {
   return true;
 }
 
-function graphemeBoundaryOffsets(text: string): number[] {
-  if (isAsciiSafe(text)) {
+function graphemeBoundaryOffsets(text: string, asciiSafe = isAsciiSafe(text)): number[] {
+  if (asciiSafe) {
     // ASCII has one UTF-16 code unit per grapheme in the range we accept here,
     // so this hot path avoids Intl.Segmenter for common English/code strings.
     return Array.from({ length: text.length + 1 }, (_, index) => index);
@@ -57,15 +85,24 @@ function graphemeBoundaryOffsets(text: string): number[] {
   return boundaryOffsets;
 }
 
-function wordBoundaryOffsets(text: string, fallbackBoundaryOffsets: readonly number[]): number[] {
-  const fallbackOffsetSet = new Set(fallbackBoundaryOffsets);
+function wordBoundaryOffsets(
+  text: string,
+  fallbackBoundaryOffsets: readonly number[],
+  asciiSafe: boolean,
+): number[] {
   const boundaryOffsets = [0];
+  let fallbackIndex = 0;
 
   for (const part of wordSegmenter.segment(text)) {
     const offset = part.index + part.segment.length;
+    while (!asciiSafe && (fallbackBoundaryOffsets[fallbackIndex] ?? Infinity) < offset) {
+      fallbackIndex += 1;
+    }
+
     // Only keep word boundaries that are also grapheme boundaries. This prevents
     // a word-level cut from landing inside a composed character.
-    if (fallbackOffsetSet.has(offset) && boundaryOffsets[boundaryOffsets.length - 1] !== offset) {
+    const isGraphemeBoundary = asciiSafe || fallbackBoundaryOffsets[fallbackIndex] === offset;
+    if (isGraphemeBoundary && boundaryOffsets[boundaryOffsets.length - 1] !== offset) {
       boundaryOffsets.push(offset);
     }
   }
@@ -78,7 +115,8 @@ function wordBoundaryOffsets(text: string, fallbackBoundaryOffsets: readonly num
 }
 
 export function prepareText(text: string, boundary: ClampBoundary = "grapheme"): PreparedText {
-  const fallbackBoundaryOffsets = graphemeBoundaryOffsets(text);
+  const asciiSafe = isAsciiSafe(text);
+  const fallbackBoundaryOffsets = graphemeBoundaryOffsets(text, asciiSafe);
 
   if (boundary === "grapheme") {
     return {
@@ -93,21 +131,9 @@ export function prepareText(text: string, boundary: ClampBoundary = "grapheme"):
   return {
     text,
     boundary,
-    boundaryOffsets: wordBoundaryOffsets(text, fallbackBoundaryOffsets),
+    boundaryOffsets: wordBoundaryOffsets(text, fallbackBoundaryOffsets, asciiSafe),
     fallbackBoundaryOffsets,
   };
-}
-
-export function splitGraphemes(text: string): string[] {
-  const prepared = prepareText(text, "grapheme");
-  const { boundaryOffsets } = prepared;
-  const graphemes: string[] = [];
-
-  for (let index = 1; index < boundaryOffsets.length; index += 1) {
-    graphemes.push(text.slice(boundaryOffsets[index - 1], boundaryOffsets[index]));
-  }
-
-  return graphemes;
 }
 
 export function displayTextForKeptCount(
@@ -115,7 +141,7 @@ export function displayTextForKeptCount(
   ratio: number,
   ellipsis: string,
   kept: number,
-  spacing: TextClampSpacing = "trim",
+  spacing: Spacing = "trim",
 ): string {
   const { boundaryOffsets, text } = prepared;
   const boundaryCount = boundaryOffsets.length - 1;
@@ -162,125 +188,129 @@ export function normalizeLocationRatio(location: LineClampLocation): number {
   return Math.max(0, Math.min(1, location));
 }
 
-export function clampTextToFit(
-  preparedText: PreparedText,
-  locationRatio: number,
-  ellipsis: string,
-  fits: (text: string) => boolean,
-  spacing: TextClampSpacing = "trim",
-  hint?: { boundaryOffsets: readonly number[]; kept: number } | null,
-): TextClampResult {
-  const boundaryCount = preparedText.boundaryOffsets.length - 1;
+export function clampTextToFit({
+  ellipsis,
+  fit,
+  hint,
+  prepared,
+  ratio,
+  spacing = "trim",
+}: FitInput): TextClampResult {
+  const boundaryCount = prepared.boundaryOffsets.length - 1;
+  let currentCandidate: string | null = null;
+
+  function applyCandidate(text: string): void {
+    if (currentCandidate === text) {
+      return;
+    }
+
+    if (typeof fit === "function") {
+      fit(text);
+    } else {
+      fit.apply(text);
+    }
+
+    currentCandidate = text;
+  }
+
+  function testCandidate(text: string): boolean {
+    if (typeof fit === "function") {
+      currentCandidate = text;
+      return fit(text);
+    }
+
+    applyCandidate(text);
+    return fit.fits();
+  }
+
   // The search helper works over indexes. For text, the index is the number of
   // boundary units kept, with at least the zero-kept ellipsis candidate present.
   const best = Math.max(
     0,
     findLastFittingIndex(
       Math.max(1, boundaryCount),
-      (kept) => fits(displayTextForKeptCount(preparedText, locationRatio, ellipsis, kept, spacing)),
-      hint?.boundaryOffsets === preparedText.boundaryOffsets ? { index: hint.kept } : null,
+      (kept) => testCandidate(displayTextForKeptCount(prepared, ratio, ellipsis, kept, spacing)),
+      hint?.boundaryOffsets === prepared.boundaryOffsets ? { index: hint.kept } : null,
     ),
   );
 
-  if (best === 0 && preparedText.fallbackBoundaryOffsets) {
+  if (best === 0 && prepared.fallbackBoundaryOffsets) {
     // Whole-word truncation should never fail completely just because a single
     // word is wider than the container; retry at grapheme granularity.
-    return clampTextToFit(
-      {
-        text: preparedText.text,
-        boundary: "grapheme",
-        boundaryOffsets: preparedText.fallbackBoundaryOffsets,
-      },
-      locationRatio,
+    return clampTextToFit({
       ellipsis,
-      fits,
-      spacing,
+      fit,
       hint,
-    );
+      prepared: {
+        text: prepared.text,
+        boundary: "grapheme",
+        boundaryOffsets: prepared.fallbackBoundaryOffsets,
+      },
+      ratio,
+      spacing,
+    });
   }
 
-  const text = displayTextForKeptCount(preparedText, locationRatio, ellipsis, best, spacing);
+  const text = displayTextForKeptCount(prepared, ratio, ellipsis, best, spacing);
 
-  // Leave the measured DOM on the exact text returned to the caller, even when
-  // the final binary-search probe happened to be a neighboring candidate.
-  fits(text);
+  // Leave the measured DOM on the exact text returned to the caller. Controller
+  // callers can apply without an extra layout read when the search ended on a
+  // neighboring candidate.
+  applyCandidate(text);
   return {
-    boundaryOffsets: preparedText.boundaryOffsets,
+    boundaryOffsets: prepared.boundaryOffsets,
     kept: best,
     text,
   };
 }
 
-export function canUseNativeClamp(
-  expanded: boolean,
-  lineLimit: number | undefined,
-  maxHeight: number | string | undefined,
-  locationRatio: number,
-  ellipsis: string,
-  boundary: ClampBoundary,
-): string | null {
-  if (
-    expanded ||
-    lineLimit !== 1 ||
-    maxHeight !== undefined ||
-    locationRatio !== 1 ||
-    boundary !== "grapheme"
-  ) {
-    // Native single-line ellipsis cannot honor custom boundaries, custom
-    // ellipsis text, or non-end locations, so those cases stay on the JS path.
-    return null;
-  }
-
-  return ellipsis === "…" ? "ellipsis" : null;
-}
-
-export function isNativeClamped(textElement: HTMLElement): boolean | null {
-  if (textElement.clientWidth <= 0 || textElement.getBoundingClientRect().width <= 0) {
-    // A zero-width element is not a reliable overflow signal; let the caller
-    // keep the unclamped source until layout becomes measurable.
-    return null;
-  }
-
-  return textElement.scrollWidth > textElement.clientWidth + 0.5;
-}
-
-export function clampTextToLayout(
-  preparedText: PreparedText,
-  rootElement: HTMLElement,
-  contentElement: HTMLElement,
-  textElement: HTMLElement,
-  locationRatio: number,
-  ellipsis: string,
-  lineLimit: number | undefined,
-  maxHeight: number | string | undefined,
-  hint?: { boundaryOffsets: readonly number[]; kept: number } | null,
-): TextClampResult | null {
-  if (rootElement.getBoundingClientRect().width <= 0) {
+export function clampTextToLayout({
+  content,
+  ellipsis,
+  hint,
+  lineLimit,
+  maxHeight,
+  prepared,
+  ratio,
+  root,
+  target,
+}: LayoutInput): TextClampResult | null {
+  if (root.getBoundingClientRect().width <= 0) {
     // Measuring against an unlaid-out root would only cache a bogus clamp.
     return null;
   }
 
-  const { text } = preparedText;
-  let currentText = textElement.textContent ?? "";
+  const { text } = prepared;
+  let currentText = target.textContent ?? "";
 
-  function applyText(nextText: string): boolean {
+  function applyText(nextText: string): void {
     if (nextText !== currentText) {
-      textElement.textContent = nextText;
+      target.textContent = nextText;
       currentText = nextText;
     }
-
-    return fitsContent(rootElement, contentElement, lineLimit, maxHeight);
   }
 
-  if (applyText(text)) {
+  const fit: FitController = {
+    apply: applyText,
+    fits: () => fitsContent(root, content, lineLimit, maxHeight),
+  };
+
+  applyText(text);
+  if (fit.fits()) {
     // The full source is the cheapest and most correct answer when it fits.
     // Store it as a warm-start hint so later shrink passes begin from full text.
     return {
-      boundaryOffsets: preparedText.boundaryOffsets,
-      kept: preparedText.boundaryOffsets.length - 1,
+      boundaryOffsets: prepared.boundaryOffsets,
+      kept: prepared.boundaryOffsets.length - 1,
       text,
     };
   }
 
-  return clampTextToFit(preparedText, locationRatio, ellipsis, applyText, "trim", hint);
+  return clampTextToFit({
+    ellipsis,
+    fit,
+    hint,
+    prepared,
+    ratio,
+  });
 }

--- a/packages/vue-clamp/tests/clamp.browser.test.ts
+++ b/packages/vue-clamp/tests/clamp.browser.test.ts
@@ -54,6 +54,15 @@ function richImage(root: HTMLElement, message: string): HTMLImageElement {
   return image;
 }
 
+function lineContentElement(root: HTMLElement): HTMLElement {
+  const content = root.querySelector('[data-part="content"]');
+  if (!(content instanceof HTMLElement)) {
+    throw new Error("Expected line clamp content element.");
+  }
+
+  return content;
+}
+
 describe("LineClamp browser contract", () => {
   it("renders plain text without role or aria-label when no truncation support is needed", async () => {
     const mounted = mountClamp({
@@ -150,7 +159,12 @@ describe("LineClamp browser contract", () => {
     const root = rootElement(mounted.container);
     await waitUntilVisible(root);
 
-    expect(textElement(root).textContent).toContain("…");
+    expect(textElement(root).textContent).toBe(
+      "abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyz",
+    );
+    expect(getComputedStyle(lineContentElement(root)).getPropertyValue("-webkit-line-clamp")).toBe(
+      "2",
+    );
     expect(await sampleVisibleLineCounts(root)).toEqual([2, 2, 2]);
   });
 
@@ -238,6 +252,56 @@ describe("LineClamp browser contract", () => {
     expect(accessibleTextElement(root)).toBeNull();
     expect((mounted.exposed.value as LineClampExposed).clamped).toBe(true);
     expect(await sampleVisibleLineCounts(root)).toEqual([1, 1, 1]);
+  });
+
+  it("allows before slot content in native multiline line-clamp mode", async () => {
+    const mounted = mountClamp({
+      text: DEMO_TEXT,
+      width: 210,
+      props: {
+        maxLines: 2,
+      },
+      before: () => h("strong", "Before"),
+    });
+
+    const root = rootElement(mounted.container);
+    await waitUntilVisible(root);
+    await settle();
+
+    expect(beforeElement(root)?.textContent).toBe("Before");
+    expect(textElement(root).textContent).toBe(DEMO_TEXT);
+    expect(getComputedStyle(lineContentElement(root)).getPropertyValue("-webkit-line-clamp")).toBe(
+      "2",
+    );
+    expect(accessibleTextElement(root)).toBeNull();
+    expect((mounted.exposed.value as LineClampExposed).clamped).toBe(true);
+    expect(await sampleVisibleLineCounts(root)).toEqual([2, 2, 2]);
+  });
+
+  it("keeps multiline after slot cases on the measured path", async () => {
+    const mounted = mountClamp({
+      text: DEMO_TEXT,
+      width: 210,
+      props: {
+        maxLines: 2,
+      },
+      after: () => h("button", { type: "button" }, "After"),
+    });
+
+    const root = rootElement(mounted.container);
+    await waitUntilVisible(root);
+    await settle(4);
+
+    const textNode = textElement(root);
+    expect(
+      getComputedStyle(lineContentElement(root)).getPropertyValue("-webkit-line-clamp"),
+    ).not.toBe("2");
+    expect(textNode.textContent).not.toBe(DEMO_TEXT);
+    expect(textNode.getAttribute("aria-hidden")).toBe("true");
+    expect(accessibleTextElement(root)?.textContent).toBe(DEMO_TEXT);
+    expect(afterElement(root)?.textContent).toBe("After");
+    expect((mounted.exposed.value as LineClampExposed).clamped).toBe(true);
+    expect(await sampleVisibleLineCounts(root)).toEqual([2, 2, 2]);
   });
 
   it("reclamps after an after slot appears when clamped state changes", async () => {
@@ -505,6 +569,7 @@ describe("LineClamp browser contract", () => {
     const mounted = mountClamp({
       text: sourceText,
       props: {
+        ellipsis: "...",
         maxLines: 2,
       },
     });
@@ -514,6 +579,7 @@ describe("LineClamp browser contract", () => {
 
     const textNode = textElement(root);
     expect(textNode.textContent).not.toBe(sourceText);
+    expect(textNode.textContent).toContain("...");
     expect(textNode.getAttribute("aria-hidden")).toBe("true");
     expect(accessibleTextElement(root)?.textContent).toBe(sourceText);
   });

--- a/packages/vue-clamp/tests/demo-page.browser.test.ts
+++ b/packages/vue-clamp/tests/demo-page.browser.test.ts
@@ -1281,11 +1281,21 @@ describe("Website demo page", () => {
     const countSlider = document.querySelector("[data-stress-count-slider]");
     const widthSlider = document.querySelector("[data-stress-width-slider]");
     const payloadSlider = document.querySelector("[data-stress-payload-slider]");
+    const afterToggle = document.querySelector("[data-stress-after-toggle]");
     const maxLinesSlider = document.querySelector("[data-stress-max-lines-slider]");
 
     for (const slider of [countSlider, widthSlider, payloadSlider, maxLinesSlider]) {
       expect(slider).toBeInstanceOf(HTMLInputElement);
     }
+    expect(afterToggle).toBeInstanceOf(HTMLInputElement);
+    expect((afterToggle as HTMLInputElement).checked).toBe(false);
+    expect(document.querySelector("[data-stress-after-state]")?.textContent?.trim()).toBe(
+      "After slot",
+    );
+    expect(document.querySelector("[data-stress-after-state]")?.getAttribute("data-enabled")).toBe(
+      "false",
+    );
+    expect(document.querySelector("[data-stress-after-slot]")).toBeNull();
     expect(document.querySelector("[data-stress-max-height-slider]")).toBeNull();
     expect(
       document.querySelector('[data-stress-limit-mode="lines"]')?.getAttribute("aria-pressed"),
@@ -1293,6 +1303,18 @@ describe("Website demo page", () => {
     expect(document.querySelector("[data-stress-native-status]")).toBeNull();
 
     expect(meter).toBeInstanceOf(HTMLElement);
+
+    (afterToggle as HTMLInputElement).click();
+    await settle(2);
+
+    expect((afterToggle as HTMLInputElement).checked).toBe(true);
+    expect(document.querySelector("[data-stress-after-state]")?.textContent?.trim()).toBe(
+      "After slot",
+    );
+    expect(document.querySelector("[data-stress-after-state]")?.getAttribute("data-enabled")).toBe(
+      "true",
+    );
+    expect(document.querySelector("[data-stress-after-slot]")).toBeInstanceOf(HTMLElement);
 
     (countSlider as HTMLInputElement).value = "1.3";
     countSlider?.dispatchEvent(new Event("input", { bubbles: true }));
@@ -1337,6 +1359,7 @@ describe("Website demo page", () => {
     maxLinesSlider?.dispatchEvent(new Event("input", { bubbles: true }));
     await settle(1);
 
+    expect(document.querySelector("[data-stress-native-status]")).toBeNull();
     expect(document.querySelector("[data-stress-width]")?.textContent).toBe("520px");
     expect(document.querySelector("[data-stress-max-lines]")?.textContent).toBe("5");
 

--- a/packages/vue-clamp/tests/demo-page.browser.test.ts
+++ b/packages/vue-clamp/tests/demo-page.browser.test.ts
@@ -1336,6 +1336,11 @@ describe("Website demo page", () => {
         (slot) => slot.textContent?.trim() === "+0",
       ),
     ).toBe(false);
+    expect(
+      [...document.querySelectorAll("[data-stress-after-slot]")].some(
+        (slot) => slot.textContent?.trim() === "Action",
+      ),
+    ).toBe(true);
 
     (widthSlider as HTMLInputElement).value = "360";
     widthSlider?.dispatchEvent(new Event("input", { bubbles: true }));

--- a/packages/vue-clamp/tests/demo-page.browser.test.ts
+++ b/packages/vue-clamp/tests/demo-page.browser.test.ts
@@ -428,6 +428,32 @@ function waitTime(ms: number): Promise<void> {
     window.setTimeout(resolve, ms);
   });
 }
+
+async function waitForDocumentElement(document: Document, selector: string): Promise<HTMLElement> {
+  for (let attempt = 0; attempt < 20; attempt += 1) {
+    await settle(1);
+
+    const element = document.querySelector(selector);
+    if (element instanceof HTMLElement) {
+      return element;
+    }
+  }
+
+  throw new Error(`Expected document element matching ${selector}.`);
+}
+
+async function waitForElementAttribute(element: HTMLElement, attribute: string): Promise<void> {
+  for (let attempt = 0; attempt < 20; attempt += 1) {
+    await settle(1);
+
+    if (element.hasAttribute(attribute)) {
+      return;
+    }
+  }
+
+  throw new Error(`Expected ${attribute} on element.`);
+}
+
 async function waitForHeroTaglineShrink(
   tagline: HTMLElement,
   minimumDelta: number,
@@ -963,6 +989,7 @@ describe("Website demo page", () => {
     expect(referencePanelNames(mountedPage.container)).toEqual([
       "overview",
       "demo",
+      "stress",
       "example",
       "api",
     ]);
@@ -1066,6 +1093,7 @@ describe("Website demo page", () => {
     expect(referencePanelNames(mountedPage.container)).toEqual([
       "overview",
       "demo",
+      "stress",
       "example",
       "api",
     ]);
@@ -1083,6 +1111,7 @@ describe("Website demo page", () => {
     expect(referencePanelNames(mountedPage.container)).toEqual([
       "overview",
       "demo",
+      "stress",
       "example",
       "api",
     ]);
@@ -1203,6 +1232,147 @@ describe("Website demo page", () => {
     expect(sharedControlsToggle(mountedPage.container, "rich").getAttribute("aria-expanded")).toBe(
       "false",
     );
+  });
+
+  it("opens a stress playground with fps and workload controls", async () => {
+    const { default: App } = await import("../../website/src/App.vue");
+    const mountedPage = mountPage(App);
+
+    await settle(4);
+    await selectSurface(mountedPage.container, "wrap");
+
+    const document = mountedPage.container.ownerDocument;
+    const openButton = mountedPage.container.querySelector("[data-stress-playground-open]");
+    if (!(openButton instanceof HTMLButtonElement)) {
+      throw new Error("Expected the stress playground open button.");
+    }
+
+    expect(document.querySelector("[data-stress-playground]")).toBeNull();
+
+    openButton.click();
+
+    const playground = await waitForDocumentElement(document, "[data-stress-playground]");
+    await settle(2);
+    expect(playground).toBeInstanceOf(HTMLElement);
+    expect(
+      document.querySelector('[data-stress-surface="wrap"]')?.getAttribute("aria-pressed"),
+    ).toBe("true");
+    expect(
+      document
+        .querySelector("[data-stress-surface-item]")
+        ?.getAttribute("data-stress-surface-item"),
+    ).toBe("wrap");
+    expect(document.querySelector("[data-fps-meter] canvas")).toBeInstanceOf(HTMLCanvasElement);
+    expect(document.querySelectorAll("[data-stress-item]")).toHaveLength(10);
+    expect(
+      document
+        .querySelector("[data-stress-modal-scroll]")
+        ?.hasAttribute("data-overlayscrollbars-initialize"),
+    ).toBe(true);
+    expect(
+      document
+        .querySelector("[data-stress-workload]")
+        ?.hasAttribute("data-overlayscrollbars-initialize"),
+    ).toBe(true);
+    expect(document.body.style.position).toBe("fixed");
+    expect(document.documentElement.style.overflow).toBe("hidden");
+
+    const meter = document.querySelector("[data-fps-meter]");
+    const countSlider = document.querySelector("[data-stress-count-slider]");
+    const widthSlider = document.querySelector("[data-stress-width-slider]");
+    const payloadSlider = document.querySelector("[data-stress-payload-slider]");
+    const maxLinesSlider = document.querySelector("[data-stress-max-lines-slider]");
+
+    for (const slider of [countSlider, widthSlider, payloadSlider, maxLinesSlider]) {
+      expect(slider).toBeInstanceOf(HTMLInputElement);
+    }
+    expect(document.querySelector("[data-stress-max-height-slider]")).toBeNull();
+    expect(
+      document.querySelector('[data-stress-limit-mode="lines"]')?.getAttribute("aria-pressed"),
+    ).toBe("true");
+    expect(document.querySelector("[data-stress-native-status]")).toBeNull();
+
+    expect(meter).toBeInstanceOf(HTMLElement);
+
+    (countSlider as HTMLInputElement).value = "1.3";
+    countSlider?.dispatchEvent(new Event("input", { bubbles: true }));
+    await settle(2);
+
+    expect(document.querySelector("[data-stress-count]")?.textContent).toBe("20");
+    expect(document.querySelectorAll("[data-stress-item]")).toHaveLength(20);
+
+    expect(document.querySelector("[data-stress-payload]")?.textContent).toBe("24 items");
+    (payloadSlider as HTMLInputElement).value = "5";
+    payloadSlider?.dispatchEvent(new Event("input", { bubbles: true }));
+    await settle(1);
+    expect(document.querySelector("[data-stress-payload]")?.textContent).toBe("40 items");
+
+    const lineSurfaceButton = document.querySelector('[data-stress-surface="line"]');
+    if (!(lineSurfaceButton instanceof HTMLButtonElement)) {
+      throw new Error("Expected the LineClamp stress surface button.");
+    }
+    lineSurfaceButton.click();
+    await settle(2);
+    expect(lineSurfaceButton.getAttribute("aria-pressed")).toBe("true");
+    expect(document.querySelector("[data-stress-payload]")?.textContent).toBe("5x text");
+    expect(
+      document
+        .querySelector("[data-stress-surface-item]")
+        ?.getAttribute("data-stress-surface-item"),
+    ).toBe("line");
+
+    (widthSlider as HTMLInputElement).value = "520";
+    widthSlider?.dispatchEvent(new Event("input", { bubbles: true }));
+    (maxLinesSlider as HTMLInputElement).value = "1";
+    maxLinesSlider?.dispatchEvent(new Event("input", { bubbles: true }));
+    await settle(1);
+
+    const nativeStatus = document.querySelector("[data-stress-native-status]");
+    expect(nativeStatus).toBeInstanceOf(HTMLElement);
+    expect(nativeStatus?.getAttribute("data-stress-native-mode")).toBe("single-line");
+    expect(nativeStatus?.textContent?.trim()).toBe("Native");
+    expect(nativeStatus?.getAttribute("title")).toBe("Native CSS text-overflow");
+
+    (maxLinesSlider as HTMLInputElement).value = "5";
+    maxLinesSlider?.dispatchEvent(new Event("input", { bubbles: true }));
+    await settle(1);
+
+    expect(document.querySelector("[data-stress-width]")?.textContent).toBe("520px");
+    expect(document.querySelector("[data-stress-max-lines]")?.textContent).toBe("5");
+
+    const heightModeButton = document.querySelector('[data-stress-limit-mode="height"]');
+    if (!(heightModeButton instanceof HTMLButtonElement)) {
+      throw new Error("Expected the height stress limit mode button.");
+    }
+    heightModeButton.click();
+    await settle(2);
+
+    expect(heightModeButton.getAttribute("aria-pressed")).toBe("true");
+    expect(document.querySelector("[data-stress-max-lines-slider]")).toBeNull();
+    expect(document.querySelector("[data-stress-native-status]")).toBeNull();
+    const maxHeightSlider = document.querySelector("[data-stress-max-height-slider]");
+    expect(maxHeightSlider).toBeInstanceOf(HTMLInputElement);
+
+    expect(document.querySelector("[data-stress-max-height]")?.textContent).toBe("96px");
+    (maxHeightSlider as HTMLInputElement).value = "140";
+    maxHeightSlider?.dispatchEvent(new Event("input", { bubbles: true }));
+    await settle(1);
+
+    expect(document.querySelector("[data-stress-max-height]")?.textContent).toBe("140px");
+    expect(document.querySelector("[data-stress-item]")?.getAttribute("data-stress-item")).toBe(
+      "height",
+    );
+
+    const closeButton = document.querySelector("[data-stress-close]");
+    if (!(closeButton instanceof HTMLButtonElement)) {
+      throw new Error("Expected the stress playground close button.");
+    }
+    closeButton.click();
+    await settle(1);
+
+    expect(document.querySelector("[data-stress-playground]")).toBeNull();
+    expect(document.body.style.position).toBe("");
+    expect(document.documentElement.style.overflow).toBe("");
   });
 
   it("scrolls to the tabs row when its in-flow top edge is above the viewport", async () => {
@@ -1368,6 +1538,8 @@ describe("Website demo page", () => {
 
     expect(firstDemoPreview).toBeInstanceOf(HTMLElement);
     expect(codeScroll).toBeInstanceOf(HTMLElement);
+    await waitForElementAttribute(firstDemoPreview as HTMLElement, "data-overlayscrollbars");
+    await waitForElementAttribute(codeScroll as HTMLElement, "data-overlayscrollbars");
     expect((firstDemoPreview as HTMLElement).hasAttribute("data-overlayscrollbars")).toBe(true);
     expect((codeScroll as HTMLElement).hasAttribute("data-overlayscrollbars")).toBe(true);
   });

--- a/packages/vue-clamp/tests/demo-page.browser.test.ts
+++ b/packages/vue-clamp/tests/demo-page.browser.test.ts
@@ -1249,6 +1249,7 @@ describe("Website demo page", () => {
 
     expect(document.querySelector("[data-stress-playground]")).toBeNull();
 
+    openButton.focus();
     openButton.click();
 
     const playground = await waitForDocumentElement(document, "[data-stress-playground]");
@@ -1396,6 +1397,7 @@ describe("Website demo page", () => {
     expect(document.querySelector("[data-stress-playground]")).toBeNull();
     expect(document.body.style.position).toBe("");
     expect(document.documentElement.style.overflow).toBe("");
+    expect(document.activeElement).toBe(openButton);
   });
 
   it("scrolls to the tabs row when its in-flow top edge is above the viewport", async () => {

--- a/packages/vue-clamp/tests/demo-page.browser.test.ts
+++ b/packages/vue-clamp/tests/demo-page.browser.test.ts
@@ -1316,8 +1316,36 @@ describe("Website demo page", () => {
       "true",
     );
     expect(document.querySelector("[data-stress-after-slot]")).toBeInstanceOf(HTMLElement);
+    expect(
+      [...document.querySelectorAll("[data-stress-after-slot]")].some((slot) => {
+        const match = /^\+(\d+)$/u.exec(slot.textContent?.trim() ?? "");
+        return match ? Number(match[1]) > 0 : false;
+      }),
+    ).toBe(true);
 
-    (countSlider as HTMLInputElement).value = "1.3";
+    (widthSlider as HTMLInputElement).value = "720";
+    widthSlider?.dispatchEvent(new Event("input", { bubbles: true }));
+    (payloadSlider as HTMLInputElement).value = "1";
+    payloadSlider?.dispatchEvent(new Event("input", { bubbles: true }));
+    (maxLinesSlider as HTMLInputElement).value = "8";
+    maxLinesSlider?.dispatchEvent(new Event("input", { bubbles: true }));
+    await settle(2);
+
+    expect(
+      [...document.querySelectorAll("[data-stress-after-slot]")].some(
+        (slot) => slot.textContent?.trim() === "+0",
+      ),
+    ).toBe(false);
+
+    (widthSlider as HTMLInputElement).value = "360";
+    widthSlider?.dispatchEvent(new Event("input", { bubbles: true }));
+    (payloadSlider as HTMLInputElement).value = "3";
+    payloadSlider?.dispatchEvent(new Event("input", { bubbles: true }));
+    (maxLinesSlider as HTMLInputElement).value = "3";
+    maxLinesSlider?.dispatchEvent(new Event("input", { bubbles: true }));
+    await settle(2);
+
+    (countSlider as HTMLInputElement).value = "20";
     countSlider?.dispatchEvent(new Event("input", { bubbles: true }));
     await settle(2);
 

--- a/packages/vue-clamp/tests/rich.browser.benchmark.ts
+++ b/packages/vue-clamp/tests/rich.browser.benchmark.ts
@@ -1,11 +1,11 @@
 import { afterAll, afterEach, beforeAll, describe, expect, it } from "vite-plus/test";
 import { createApp, defineComponent, h, nextTick, ref } from "vue";
 import { RichLineClamp } from "../src/index.ts";
-import { clampRichTextToLayout, prepareRichText } from "../src/rich.ts";
+import { clampRich, prepareRich } from "../src/rich.ts";
 import { frame } from "./browser.ts";
 
 import type { App, Ref } from "vue";
-import type { RichClampDecision } from "../src/rich.ts";
+import type { RichState } from "../src/rich.ts";
 
 type BenchmarkMetrics = {
   boundingRectReads: number;
@@ -54,13 +54,13 @@ type ScenarioResult = {
 };
 
 type MountedHost = {
+  body: HTMLElement;
   container: HTMLElement;
   content: HTMLElement;
-  decision: RichClampDecision | null;
   destroy: () => void;
-  rich: HTMLElement;
   root: HTMLElement;
   setWidth: (width: number) => void;
+  state: RichState | null;
 };
 
 type ComponentHost = {
@@ -250,57 +250,39 @@ function mountHost(html: string, width: number): MountedHost {
   container.append(root);
 
   return {
+    body,
     container,
     content,
-    decision: null,
     destroy: () => {
       container.remove();
     },
-    rich: body,
     root,
     setWidth: (nextWidth) => {
       root.style.width = `${nextWidth}px`;
     },
+    state: null,
   };
 }
 
 function runClamp(
-  prepared: NonNullable<ReturnType<typeof prepareRichText>>,
+  prepared: NonNullable<ReturnType<typeof prepareRich>>,
   host: MountedHost,
   maxLines: number,
-  searchDecision: RichClampDecision | null,
+  hint: RichState | null,
 ): void {
-  const clamp = clampRichTextToLayout as unknown as (...args: unknown[]) => {
-    decision: RichClampDecision | null;
-    fallback: boolean;
-  };
-  const result =
-    clamp.length >= 9
-      ? clamp(
-          prepared,
-          host.root,
-          host.content,
-          host.rich,
-          host.decision,
-          searchDecision,
-          "…",
-          maxLines,
-          undefined,
-        )
-      : clamp(
-          prepared,
-          host.root,
-          host.content,
-          host.rich,
-          host.decision,
-          "…",
-          maxLines,
-          undefined,
-        );
-  host.decision = result.decision;
+  const result = clampRich({
+    ellipsis: "…",
+    from: host.state,
+    hint,
+    lineLimit: maxLines,
+    maxHeight: undefined,
+    prepared,
+    probe: host,
+  });
+  host.state = result.state;
 
-  if (!result.decision) {
-    throw new Error("Rich benchmark returned null decision.");
+  if (!result.state) {
+    throw new Error("Rich benchmark returned null state.");
   }
 }
 
@@ -316,7 +298,7 @@ async function runDirectScenario(spec: DirectScenarioSpec): Promise<BenchmarkRun
     await frame();
 
     const prepared = spec.htmls.map((html) => {
-      const nextPrepared = prepareRichText(html);
+      const nextPrepared = prepareRich(html);
       if (!nextPrepared) {
         throw new Error(`Rich benchmark could not prepare html for ${spec.name}.`);
       }
@@ -344,7 +326,7 @@ async function runDirectScenario(spec: DirectScenarioSpec): Promise<BenchmarkRun
           prepared[index]!,
           hosts[index]!,
           spec.maxLines,
-          spec.cache === "warm" ? hosts[index]!.decision : null,
+          spec.cache === "warm" ? hosts[index]!.state : null,
         );
       }
 

--- a/packages/vue-clamp/tests/text.browser.benchmark.ts
+++ b/packages/vue-clamp/tests/text.browser.benchmark.ts
@@ -263,14 +263,14 @@ function resultFrom(value: unknown, prepared: PreparedText): TextClampResult | n
 
 function clampTextToFit({
   ellipsis,
-  fit,
+  fits,
   hint,
   prepared,
   ratio,
   spacing,
 }: {
   ellipsis: string;
-  fit: (text: string) => boolean;
+  fits: (text: string) => boolean;
   hint: TextClampHint | null;
   prepared: PreparedText;
   ratio: number;
@@ -285,7 +285,7 @@ function clampTextToFit({
   const result = resultFrom(
     (clamp as (...args: unknown[]) => unknown)({
       ellipsis,
-      fit,
+      fits,
       hint,
       prepared,
       ratio,
@@ -424,7 +424,7 @@ function runInlineClamp(
 
   const result = clampTextToFit({
     ellipsis: "…",
-    fit: (candidate: string) => {
+    fits: (candidate: string) => {
       host.body.textContent = candidate;
       return fits();
     },

--- a/packages/vue-clamp/tests/text.browser.benchmark.ts
+++ b/packages/vue-clamp/tests/text.browser.benchmark.ts
@@ -261,23 +261,36 @@ function resultFrom(value: unknown, prepared: PreparedText): TextClampResult | n
   return value as TextClampResult;
 }
 
-function clampTextToFit(
-  prepared: PreparedText,
-  ratio: number,
-  ellipsis: string,
-  fits: (text: string) => boolean,
-  spacing: "trim" | "preserve-outer",
-  hint: TextClampHint | null,
-): TextClampResult {
+function clampTextToFit({
+  ellipsis,
+  fit,
+  hint,
+  prepared,
+  ratio,
+  spacing,
+}: {
+  ellipsis: string;
+  fit: (text: string) => boolean;
+  hint: TextClampHint | null;
+  prepared: PreparedText;
+  ratio: number;
+  spacing: "trim" | "preserve-outer";
+}): TextClampResult {
   const module = textModule();
   const clamp =
     module.clampTextToFit ??
-    module.searchClampedTextToFit ??
     (() => {
       throw new Error("Missing text fit helper.");
     });
   const result = resultFrom(
-    (clamp as (...args: unknown[]) => unknown)(prepared, ratio, ellipsis, fits, spacing, hint),
+    (clamp as (...args: unknown[]) => unknown)({
+      ellipsis,
+      fit,
+      hint,
+      prepared,
+      ratio,
+      spacing,
+    }),
     prepared,
   );
 
@@ -295,17 +308,17 @@ function clampTextToLayout(
   maxLines: number,
   hint: TextClampHint | null,
 ): TextClampResult | null {
-  const result = (textModule().clampTextToLayout as (...args: unknown[]) => unknown)(
-    prepared,
-    host.root,
-    host.content,
-    host.text,
-    ratio,
-    "…",
-    maxLines,
-    undefined,
+  const result = (textModule().clampTextToLayout as (...args: unknown[]) => unknown)({
+    content: host.content,
+    ellipsis: "…",
     hint,
-  );
+    lineLimit: maxLines,
+    maxHeight: undefined,
+    prepared,
+    ratio,
+    root: host.root,
+    target: host.text,
+  });
 
   return resultFrom(result, prepared);
 }
@@ -409,17 +422,17 @@ function runInlineClamp(
     };
   }
 
-  const result = clampTextToFit(
-    prepared,
-    ratio,
-    "…",
-    (candidate) => {
+  const result = clampTextToFit({
+    ellipsis: "…",
+    fit: (candidate: string) => {
       host.body.textContent = candidate;
       return fits();
     },
-    "preserve-outer",
+    prepared,
+    ratio,
+    spacing: "preserve-outer",
     hint,
-  );
+  });
   host.body.textContent = result.text;
   return result;
 }

--- a/packages/vue-clamp/tests/text.test.ts
+++ b/packages/vue-clamp/tests/text.test.ts
@@ -52,7 +52,7 @@ describe("text helpers", () => {
     expect(
       clampTextToFit({
         ellipsis: "…",
-        fit: (text) => text.length <= 8,
+        fits: (text) => text.length <= 8,
         prepared,
         ratio: 1,
       }).text,
@@ -70,13 +70,13 @@ describe("text helpers", () => {
 
     const cold = clampTextToFit({
       ellipsis: "…",
-      fit: fits(coldProbes),
+      fits: fits(coldProbes),
       prepared,
       ratio: 1,
     });
     const warm = clampTextToFit({
       ellipsis: "…",
-      fit: fits(warmProbes),
+      fits: fits(warmProbes),
       hint: {
         boundaryOffsets: prepared.boundaryOffsets,
         kept: 40,
@@ -96,7 +96,7 @@ describe("text helpers", () => {
     const probes: number[] = [];
     const result = clampTextToFit({
       ellipsis: "…",
-      fit: (text) => {
+      fits: (text) => {
         probes.push(text.length);
         return text.length <= 37;
       },
@@ -111,30 +111,5 @@ describe("text helpers", () => {
     expect(result.kept).toBe(36);
     expect(probes[0]).toBe(43);
     expect(probes).toContain(37);
-  });
-
-  it("can apply the final text without retesting layout", () => {
-    const prepared = prepareText("x".repeat(8));
-    const applied: string[] = [];
-    const tested: string[] = [];
-    const result = clampTextToFit({
-      ellipsis: "…",
-      fit: {
-        apply(text) {
-          applied.push(text);
-        },
-        fits() {
-          const current = applied.at(-1) ?? "";
-          tested.push(current);
-          return current.length <= 4;
-        },
-      },
-      prepared,
-      ratio: 1,
-    });
-
-    expect(result.text).toBe("xxx…");
-    expect(applied.at(-1)).toBe(result.text);
-    expect(tested.at(-1)).not.toBe(result.text);
   });
 });

--- a/packages/vue-clamp/tests/text.test.ts
+++ b/packages/vue-clamp/tests/text.test.ts
@@ -1,18 +1,19 @@
 import { describe, expect, it } from "vite-plus/test";
-import {
-  displayTextForKeptCount,
-  prepareText,
-  clampTextToFit,
-  splitGraphemes,
-} from "../src/text.ts";
+import { displayTextForKeptCount, prepareText, clampTextToFit } from "../src/text.ts";
 
 describe("text helpers", () => {
-  it("splits ascii text into single characters", () => {
-    expect(splitGraphemes("abc")).toEqual(["a", "b", "c"]);
+  it("prepares ascii text as single-code-unit grapheme boundaries", () => {
+    expect(prepareText("abc").boundaryOffsets).toEqual([0, 1, 2, 3]);
   });
 
   it("keeps grapheme clusters intact for emoji", () => {
-    expect(splitGraphemes("a👨‍👩‍👧‍👦b")).toEqual(["a", "👨‍👩‍👧‍👦", "b"]);
+    const text = "a👨‍👩‍👧‍👦b";
+    const { boundaryOffsets } = prepareText(text);
+    const graphemes = boundaryOffsets
+      .slice(1)
+      .map((end, index) => text.slice(boundaryOffsets[index], end));
+
+    expect(graphemes).toEqual(["a", "👨‍👩‍👧‍👦", "b"]);
   });
 
   it("builds end-clamped text from a kept grapheme count", () => {
@@ -48,7 +49,14 @@ describe("text helpers", () => {
   it("falls back to grapheme boundaries when no word boundary fits", () => {
     const prepared = prepareText("supercalifragilistic", "word");
 
-    expect(clampTextToFit(prepared, 1, "…", (text) => text.length <= 8).text).toBe("superca…");
+    expect(
+      clampTextToFit({
+        ellipsis: "…",
+        fit: (text) => text.length <= 8,
+        prepared,
+        ratio: 1,
+      }).text,
+    ).toBe("superca…");
   });
 
   it("can warm-start text fitting near the previous fit", () => {
@@ -60,10 +68,21 @@ describe("text helpers", () => {
       return text.length <= 43;
     };
 
-    const cold = clampTextToFit(prepared, 1, "…", fits(coldProbes));
-    const warm = clampTextToFit(prepared, 1, "…", fits(warmProbes), "trim", {
-      boundaryOffsets: prepared.boundaryOffsets,
-      kept: 40,
+    const cold = clampTextToFit({
+      ellipsis: "…",
+      fit: fits(coldProbes),
+      prepared,
+      ratio: 1,
+    });
+    const warm = clampTextToFit({
+      ellipsis: "…",
+      fit: fits(warmProbes),
+      hint: {
+        boundaryOffsets: prepared.boundaryOffsets,
+        kept: 40,
+      },
+      prepared,
+      ratio: 1,
     });
 
     expect(cold.kept).toBe(42);
@@ -75,23 +94,47 @@ describe("text helpers", () => {
   it("can warm-start text fitting downward from an oversized previous fit", () => {
     const prepared = prepareText("x".repeat(100));
     const probes: number[] = [];
-    const result = clampTextToFit(
-      prepared,
-      1,
-      "…",
-      (text) => {
+    const result = clampTextToFit({
+      ellipsis: "…",
+      fit: (text) => {
         probes.push(text.length);
         return text.length <= 37;
       },
-      "trim",
-      {
+      hint: {
         boundaryOffsets: prepared.boundaryOffsets,
         kept: 42,
       },
-    );
+      prepared,
+      ratio: 1,
+    });
 
     expect(result.kept).toBe(36);
     expect(probes[0]).toBe(43);
     expect(probes).toContain(37);
+  });
+
+  it("can apply the final text without retesting layout", () => {
+    const prepared = prepareText("x".repeat(8));
+    const applied: string[] = [];
+    const tested: string[] = [];
+    const result = clampTextToFit({
+      ellipsis: "…",
+      fit: {
+        apply(text) {
+          applied.push(text);
+        },
+        fits() {
+          const current = applied.at(-1) ?? "";
+          tested.push(current);
+          return current.length <= 4;
+        },
+      },
+      prepared,
+      ratio: 1,
+    });
+
+    expect(result.text).toBe("xxx…");
+    expect(applied.at(-1)).toBe(result.text);
+    expect(tested.at(-1)).not.toBe(result.text);
   });
 });

--- a/packages/vue-clamp/tests/wrap.browser.test.ts
+++ b/packages/vue-clamp/tests/wrap.browser.test.ts
@@ -162,6 +162,32 @@ function wrapSnapshot(root: HTMLElement): { after: string | null; items: string[
   };
 }
 
+function wrapLineCount(root: HTMLElement): number {
+  const tops: number[] = [];
+
+  for (const child of wrapContent(root).children) {
+    if (!(child instanceof HTMLElement)) {
+      continue;
+    }
+
+    const part = child.dataset.part;
+    if (part !== "before" && part !== "item" && part !== "after") {
+      continue;
+    }
+
+    const rect = child.getBoundingClientRect();
+    if (rect.width <= 0 || rect.height <= 0) {
+      continue;
+    }
+
+    if (!tops.some((top) => Math.abs(top - rect.top) <= 0.5)) {
+      tops.push(rect.top);
+    }
+  }
+
+  return tops.length;
+}
+
 afterEach(() => {
   for (const mountedClamp of mounted) {
     mountedClamp.app.unmount();
@@ -278,6 +304,44 @@ describe("WrapClamp browser contract", () => {
       after: "+1",
       items: ["Alpha", "Beta"],
     });
+  });
+
+  it("settles across a hiddenItems digit boundary when grow changes after width", async () => {
+    const items = Array.from({ length: 20 }, (_, index) => `I${index + 1}`);
+    const mountedClamp = mountWrapClamp({
+      items,
+      props: {
+        maxLines: 1,
+      },
+      width: 324,
+      item: ({ item }) => h("span", { style: fixedBadgeStyle(20) }, item),
+      after: ({ clamped, hiddenItems }) =>
+        clamped
+          ? h(
+              "span",
+              { style: fixedBadgeStyle(hiddenItems.length >= 10 ? 64 : 32) },
+              `+${hiddenItems.length}`,
+            )
+          : null,
+    });
+
+    await settle(5);
+    expect(wrapSnapshot(rootElement(mountedClamp.container))).toEqual({
+      after: "+11",
+      items: items.slice(0, 9),
+    });
+
+    mountedClamp.width.value = 420;
+    await settle(8);
+
+    const root = rootElement(mountedClamp.container);
+    const grownSnapshot = wrapSnapshot(root);
+    const hiddenCount = items.length - grownSnapshot.items.length;
+    expect(hiddenCount).toBeGreaterThan(0);
+    expect(hiddenCount).toBeLessThan(10);
+    expect(grownSnapshot.after).toBe(`+${hiddenCount}`);
+    expect(grownSnapshot.items).toEqual(items.slice(0, grownSnapshot.items.length));
+    expect(wrapLineCount(root)).toBeLessThanOrEqual(1);
   });
 
   it("falls back cleanly when a single item is wider than the container", async () => {

--- a/packages/website/package.json
+++ b/packages/website/package.json
@@ -12,11 +12,13 @@
     "@lucide/vue": "catalog:",
     "overlayscrollbars": "catalog:",
     "simple-icons": "catalog:",
+    "stats.js": "catalog:",
     "vue": "catalog:",
     "vue-clamp": "workspace:*"
   },
   "devDependencies": {
     "@types/node": "catalog:",
+    "@types/stats.js": "catalog:",
     "@vitejs/plugin-vue": "catalog:",
     "shiki": "catalog:",
     "typescript": "catalog:",

--- a/packages/website/src/App.vue
+++ b/packages/website/src/App.vue
@@ -1,34 +1,26 @@
 <script setup lang="ts">
-import { computed, defineAsyncComponent, nextTick, onBeforeUnmount, onMounted, ref } from "vue";
+import {
+  computed,
+  defineAsyncComponent,
+  nextTick,
+  onBeforeUnmount,
+  onMounted,
+  ref,
+  watch,
+} from "vue";
 import { ArrowUpRight, ChevronDown, Ellipsis, Gauge, SlidersHorizontal } from "@lucide/vue";
 import { siGithub } from "simple-icons";
 import { InlineClamp, LineClamp, RichLineClamp, WrapClamp } from "vue-clamp";
 import Alert from "./Alert.vue";
 import ComponentTabs from "./ComponentTabs.vue";
-import CodeBlock from "./CodeBlock.vue";
 import PillControls from "./PillControls.vue";
 import {
   horizontalOverlayScrollbarsOptions,
   initBodyOverlayScrollbars,
   overlayScrollbarsDirective,
 } from "./overlayScrollbars";
-import { createHighlighterCoreSync } from "shiki/core";
-import { createJavaScriptRegexEngine } from "shiki/engine/javascript";
-import vue from "shiki/langs/vue.mjs";
-import shellscript from "shiki/langs/shellscript.mjs";
-import css from "shiki/langs/css.mjs";
-import html from "shiki/langs/html.mjs";
-import js from "shiki/langs/javascript.mjs";
-import ts from "shiki/langs/typescript.mjs";
-import { websiteShikiTheme } from "./shiki-theme";
 
 import type { ClampBoundary, InlineClampSplit, LineClampLocation } from "vue-clamp";
-
-const shiki = createHighlighterCoreSync({
-  themes: [websiteShikiTheme],
-  langs: [vue, shellscript, css, html, js, ts],
-  engine: createJavaScriptRegexEngine(),
-});
 
 const vOverlayScrollbars = overlayScrollbarsDirective;
 const horizontalOverlayScrollbars = horizontalOverlayScrollbarsOptions;
@@ -282,6 +274,7 @@ const activeSurface = ref<SurfaceKey>(currentSurfaceFromLocation() ?? "line");
 const referenceTabsAnchorRef = ref<HTMLElement | null>(null);
 const demoControlsExpanded = ref(false);
 const stressPlaygroundOpen = ref(false);
+const CodeBlock = defineAsyncComponent(() => import("./CodeBlock.vue"));
 const StressPlayground = defineAsyncComponent(() => import("./StressPlayground.vue"));
 const surfaceGuideItems = [
   {
@@ -465,7 +458,7 @@ let heroTaglineTimer: number | null = null;
 let heroTaglineMotionQuery: MediaQueryList | null = null;
 let heroTaglineResizeObserver: ResizeObserver | null = null;
 let heroTaglineFontsReady = false;
-let heroTaglineMounted = false;
+let pageMounted = false;
 let stopBodyOverlayScrollbars = () => {};
 
 const inlineWidth5 = ref(280);
@@ -669,7 +662,9 @@ const demoControlsSummary = computed(() => {
         selectedInlineLocationPreset5.value ?? inlineLocationRatio5.value.toFixed(2),
         boundaryLabel(inlineBoundary5.value),
         `${inlineWidth5.value}px`,
-      ].join(" · ");
+      ]
+        .filter((part): part is string => Boolean(part))
+        .join(" · ");
     case "wrap":
       return [`${wrapWidth.value}px`, boolFlag(wrapRtl.value, "RTL")]
         .filter((part): part is string => Boolean(part))
@@ -896,8 +891,9 @@ function handleWrapTabsKeydown(event: KeyboardEvent): void {
 }
 
 onMounted(() => {
-  heroTaglineMounted = true;
+  pageMounted = true;
   stopBodyOverlayScrollbars = initBodyOverlayScrollbars();
+  void loadHighlightedCode();
   document.addEventListener("pointerdown", handleWrapTabsPointerDown);
   document.addEventListener("keydown", handleWrapTabsKeydown);
   window.addEventListener("hashchange", handleSurfaceHashChange);
@@ -922,7 +918,7 @@ onMounted(() => {
   void (async () => {
     await waitForFonts();
 
-    if (!heroTaglineMounted) {
+    if (!pageMounted) {
       return;
     }
 
@@ -941,7 +937,8 @@ onMounted(() => {
 
 onBeforeUnmount(() => {
   heroTaglineFontsReady = false;
-  heroTaglineMounted = false;
+  pageMounted = false;
+  highlightRequestId += 1;
   stopBodyOverlayScrollbars();
   document.removeEventListener("pointerdown", handleWrapTabsPointerDown);
   document.removeEventListener("keydown", handleWrapTabsKeydown);
@@ -1123,27 +1120,34 @@ const wrapCodeExample = [
   "</template>",
 ].join("\n");
 
-const highlightedInstall = computed(() => {
-  if (pkgManager.value === "agent") {
-    return null;
-  }
-  return shiki.codeToHtml(installCommand.value, {
-    lang: "shellscript",
-    theme: websiteShikiTheme.name,
-  });
-});
+const highlightedInstall = ref<string | null>(null);
+const highlightedLineCode = ref<string | null>(null);
+const highlightedRichCode = ref<string | null>(null);
+const highlightedInlineCode = ref<string | null>(null);
+const highlightedWrapCode = ref<string | null>(null);
+let highlightRequestId = 0;
 
-function highlightCode(code: string, lang: "shellscript" | "vue"): string {
-  return shiki.codeToHtml(code, {
-    lang,
-    theme: websiteShikiTheme.name,
-  });
+async function loadHighlightedCode(): Promise<void> {
+  const requestId = (highlightRequestId += 1);
+  const { highlightCode } = await import("./highlight");
+
+  if (!pageMounted || requestId !== highlightRequestId) {
+    return;
+  }
+
+  highlightedInstall.value =
+    pkgManager.value === "agent" ? null : highlightCode(installCommand.value, "shellscript");
+  highlightedLineCode.value = highlightCode(lineCodeExample, "vue");
+  highlightedRichCode.value = highlightCode(richCodeExample, "vue");
+  highlightedInlineCode.value = highlightCode(inlineCodeExample, "vue");
+  highlightedWrapCode.value = highlightCode(wrapCodeExample, "vue");
 }
 
-const highlightedLineCode = computed(() => highlightCode(lineCodeExample, "vue"));
-const highlightedRichCode = computed(() => highlightCode(richCodeExample, "vue"));
-const highlightedInlineCode = computed(() => highlightCode(inlineCodeExample, "vue"));
-const highlightedWrapCode = computed(() => highlightCode(wrapCodeExample, "vue"));
+watch(installCommand, () => {
+  if (pageMounted) {
+    void loadHighlightedCode();
+  }
+});
 </script>
 
 <template>
@@ -3697,7 +3701,6 @@ pre code {
 
 .demo-shared-controls .control-label {
   width: auto;
-  min-width: 58px;
 }
 
 .demo-shared-controls .control-stack {

--- a/packages/website/src/App.vue
+++ b/packages/website/src/App.vue
@@ -4733,6 +4733,7 @@ pre code {
     overflow: hidden;
     font-size: 0.72rem;
     font-weight: 500;
+    font-variant-numeric: tabular-nums;
     line-height: 1.35;
     color: var(--c-text-3);
     text-overflow: ellipsis;

--- a/packages/website/src/App.vue
+++ b/packages/website/src/App.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
-import { computed, nextTick, onBeforeUnmount, onMounted, ref } from "vue";
-import { ArrowUpRight, ChevronDown, Ellipsis, SlidersHorizontal } from "@lucide/vue";
+import { computed, defineAsyncComponent, nextTick, onBeforeUnmount, onMounted, ref } from "vue";
+import { ArrowUpRight, ChevronDown, Ellipsis, Gauge, SlidersHorizontal } from "@lucide/vue";
 import { siGithub } from "simple-icons";
 import { InlineClamp, LineClamp, RichLineClamp, WrapClamp } from "vue-clamp";
 import Alert from "./Alert.vue";
@@ -281,6 +281,8 @@ function setSurfaceRouteHash(surface: SurfaceKey): void {
 const activeSurface = ref<SurfaceKey>(currentSurfaceFromLocation() ?? "line");
 const referenceTabsAnchorRef = ref<HTMLElement | null>(null);
 const demoControlsExpanded = ref(false);
+const stressPlaygroundOpen = ref(false);
+const StressPlayground = defineAsyncComponent(() => import("./StressPlayground.vue"));
 const surfaceGuideItems = [
   {
     description:
@@ -2217,6 +2219,29 @@ const highlightedWrapCode = computed(() => highlightCode(wrapCodeExample, "vue")
             </div>
           </section>
 
+          <section
+            class="reference-section stress-playground-section"
+            data-reference-panel="stress"
+          >
+            <h3 class="subsection-title">Stress playground</h3>
+            <div class="stress-playground-row">
+              <button
+                class="stress-playground-open"
+                data-stress-playground-open
+                type="button"
+                @click="stressPlaygroundOpen = true"
+              >
+                <Gauge :size="15" :stroke-width="2" aria-hidden="true" />
+                <span>Open playground</span>
+              </button>
+            </div>
+            <StressPlayground
+              v-if="stressPlaygroundOpen"
+              :initial-surface="activeSurface"
+              @close="stressPlaygroundOpen = false"
+            />
+          </section>
+
           <section class="reference-section" data-reference-panel="example">
             <h3 class="subsection-title">Usage</h3>
             <CodeBlock
@@ -3583,6 +3608,48 @@ pre code {
 }
 
 /* Demo blocks */
+
+.stress-playground-section {
+  text-align: center;
+}
+
+.stress-playground-row {
+  display: flex;
+  justify-content: center;
+  margin: 0;
+}
+
+.stress-playground-open {
+  display: inline-flex;
+  align-items: center;
+  min-height: 32px;
+  padding: 0 11px;
+  gap: 7px;
+  font-size: 0.8rem;
+  font-weight: 600;
+  font-family: inherit;
+  color: var(--c-text-2);
+  background: transparent;
+  border: 1px solid var(--c-border);
+  border-radius: 8px;
+  cursor: pointer;
+  transition:
+    background 0.15s,
+    border-color 0.15s,
+    color 0.15s,
+    box-shadow 0.15s;
+}
+
+.stress-playground-open:hover {
+  color: var(--c-accent-text);
+  background: color-mix(in srgb, var(--c-accent-soft) 74%, var(--c-bg));
+  border-color: color-mix(in srgb, var(--c-accent) 28%, transparent);
+}
+
+.stress-playground-open:focus-visible {
+  outline: none;
+  box-shadow: var(--focus-ring);
+}
 
 .demo-surface {
   display: flex;

--- a/packages/website/src/App.vue
+++ b/packages/website/src/App.vue
@@ -14,16 +14,11 @@ import { InlineClamp, LineClamp, RichLineClamp, WrapClamp } from "vue-clamp";
 import Alert from "./Alert.vue";
 import ComponentTabs from "./ComponentTabs.vue";
 import PillControls from "./PillControls.vue";
-import {
-  horizontalOverlayScrollbarsOptions,
-  initBodyOverlayScrollbars,
-  overlayScrollbarsDirective,
-} from "./overlayScrollbars";
+import { initBodyOverlayScrollbars, overlayScrollbarsDirective } from "./overlayScrollbars";
 
 import type { ClampBoundary, InlineClampSplit, LineClampLocation } from "vue-clamp";
 
 const vOverlayScrollbars = overlayScrollbarsDirective;
-const horizontalOverlayScrollbars = horizontalOverlayScrollbarsOptions;
 
 const englishText =
   "Vue (pronounced /vju\u02D0/, like view) is a progressive framework for building user interfaces. Unlike other monolithic frameworks, Vue is designed from the ground up to be incrementally adoptable. The core library is focused on the view layer only, and is easy to pick up and integrate with other libraries or existing projects. On the other hand, Vue is also perfectly capable of powering sophisticated Single-Page Applications when used in combination with modern tooling and supporting libraries.";
@@ -1527,7 +1522,7 @@ watch(installCommand, () => {
                         />
                       </label>
                     </div>
-                    <div v-overlay-scrollbars="horizontalOverlayScrollbars" class="demo-preview">
+                    <div v-overlay-scrollbars.x class="demo-preview">
                       <div class="demo-output width-guide" :style="{ width: `${lineWidth}px` }">
                         <LineClamp
                           class="demo-clamp"
@@ -1564,7 +1559,7 @@ watch(installCommand, () => {
                         </label>
                       </div>
                     </div>
-                    <div v-overlay-scrollbars="horizontalOverlayScrollbars" class="demo-preview">
+                    <div v-overlay-scrollbars.x class="demo-preview">
                       <div
                         class="demo-output width-guide height-guide"
                         :style="{ width: `${lineWidth}px` }"
@@ -1602,7 +1597,7 @@ watch(installCommand, () => {
                         />
                       </label>
                     </div>
-                    <div v-overlay-scrollbars="horizontalOverlayScrollbars" class="demo-preview">
+                    <div v-overlay-scrollbars.x class="demo-preview">
                       <div class="demo-output width-guide" :style="{ width: `${lineWidth}px` }">
                         <LineClamp
                           class="demo-clamp"
@@ -1673,7 +1668,7 @@ watch(installCommand, () => {
                         />
                       </label>
                     </div>
-                    <div v-overlay-scrollbars="horizontalOverlayScrollbars" class="demo-preview">
+                    <div v-overlay-scrollbars.x class="demo-preview">
                       <div class="demo-output width-guide" :style="{ width: `${lineWidth}px` }">
                         <LineClamp
                           class="demo-clamp"
@@ -1810,7 +1805,7 @@ watch(installCommand, () => {
                       />
                     </label>
                   </div>
-                  <div v-overlay-scrollbars="horizontalOverlayScrollbars" class="demo-preview">
+                  <div v-overlay-scrollbars.x class="demo-preview">
                     <div class="demo-output width-guide" :style="{ width: `${richWidth}px` }">
                       <RichLineClamp
                         class="demo-clamp demo-rich-card"
@@ -1851,7 +1846,7 @@ watch(installCommand, () => {
                       </label>
                     </div>
                   </div>
-                  <div v-overlay-scrollbars="horizontalOverlayScrollbars" class="demo-preview">
+                  <div v-overlay-scrollbars.x class="demo-preview">
                     <div
                       class="demo-output width-guide height-guide"
                       :style="{ width: `${richWidth}px` }"
@@ -1888,7 +1883,7 @@ watch(installCommand, () => {
                       />
                     </label>
                   </div>
-                  <div v-overlay-scrollbars="horizontalOverlayScrollbars" class="demo-preview">
+                  <div v-overlay-scrollbars.x class="demo-preview">
                     <div class="demo-output width-guide" :style="{ width: `${richWidth}px` }">
                       <RichLineClamp
                         class="demo-clamp demo-rich-card"
@@ -2014,7 +2009,7 @@ watch(installCommand, () => {
                   :data-inline-example="example.id"
                 >
                   <div class="demo-label">{{ example.label }}</div>
-                  <div v-overlay-scrollbars="horizontalOverlayScrollbars" class="demo-preview">
+                  <div v-overlay-scrollbars.x class="demo-preview">
                     <div class="comparison-grid">
                       <div class="comparison-panel" data-inline-mode="plain">
                         <div class="comparison-label">Plain</div>
@@ -2114,7 +2109,7 @@ watch(installCommand, () => {
                   <div class="demo-label">
                     tabs / fixed one-line / hidden items in <code>after</code>
                   </div>
-                  <div v-overlay-scrollbars="horizontalOverlayScrollbars" class="demo-preview">
+                  <div v-overlay-scrollbars.x class="demo-preview">
                     <div class="demo-output width-guide" :style="{ width: `${wrapWidth}px` }">
                       <WrapClamp
                         class="demo-wrap wrap-tabs"
@@ -2195,7 +2190,7 @@ watch(installCommand, () => {
                       </label>
                     </div>
                   </div>
-                  <div v-overlay-scrollbars="horizontalOverlayScrollbars" class="demo-preview">
+                  <div v-overlay-scrollbars.x class="demo-preview">
                     <div
                       class="demo-output width-guide height-guide"
                       :style="{ width: `${wrapWidth}px` }"

--- a/packages/website/src/App.vue
+++ b/packages/website/src/App.vue
@@ -274,6 +274,7 @@ const activeSurface = ref<SurfaceKey>(currentSurfaceFromLocation() ?? "line");
 const referenceTabsAnchorRef = ref<HTMLElement | null>(null);
 const demoControlsExpanded = ref(false);
 const stressPlaygroundOpen = ref(false);
+const stressPlaygroundOpenButtonRef = ref<HTMLButtonElement | null>(null);
 const CodeBlock = defineAsyncComponent(() => import("./CodeBlock.vue"));
 const StressPlayground = defineAsyncComponent(() => import("./StressPlayground.vue"));
 const surfaceGuideItems = [
@@ -2230,6 +2231,7 @@ watch(installCommand, () => {
             <h3 class="subsection-title">Stress playground</h3>
             <div class="stress-playground-row">
               <button
+                ref="stressPlaygroundOpenButtonRef"
                 class="stress-playground-open"
                 data-stress-playground-open
                 type="button"
@@ -2242,6 +2244,7 @@ watch(installCommand, () => {
             <StressPlayground
               v-if="stressPlaygroundOpen"
               :initial-surface="activeSurface"
+              :return-focus-to="stressPlaygroundOpenButtonRef"
               @close="stressPlaygroundOpen = false"
             />
           </section>

--- a/packages/website/src/App.vue
+++ b/packages/website/src/App.vue
@@ -1128,20 +1128,35 @@ const highlightedInlineCode = ref<string | null>(null);
 const highlightedWrapCode = ref<string | null>(null);
 let highlightRequestId = 0;
 
+function clearHighlightedCode(): void {
+  highlightedInstall.value = null;
+  highlightedLineCode.value = null;
+  highlightedRichCode.value = null;
+  highlightedInlineCode.value = null;
+  highlightedWrapCode.value = null;
+}
+
 async function loadHighlightedCode(): Promise<void> {
   const requestId = (highlightRequestId += 1);
-  const { highlightCode } = await import("./highlight");
 
-  if (!pageMounted || requestId !== highlightRequestId) {
-    return;
+  try {
+    const { highlightCode } = await import("./highlight");
+
+    if (!pageMounted || requestId !== highlightRequestId) {
+      return;
+    }
+
+    highlightedInstall.value =
+      pkgManager.value === "agent" ? null : highlightCode(installCommand.value, "shellscript");
+    highlightedLineCode.value = highlightCode(lineCodeExample, "vue");
+    highlightedRichCode.value = highlightCode(richCodeExample, "vue");
+    highlightedInlineCode.value = highlightCode(inlineCodeExample, "vue");
+    highlightedWrapCode.value = highlightCode(wrapCodeExample, "vue");
+  } catch {
+    if (pageMounted && requestId === highlightRequestId) {
+      clearHighlightedCode();
+    }
   }
-
-  highlightedInstall.value =
-    pkgManager.value === "agent" ? null : highlightCode(installCommand.value, "shellscript");
-  highlightedLineCode.value = highlightCode(lineCodeExample, "vue");
-  highlightedRichCode.value = highlightCode(richCodeExample, "vue");
-  highlightedInlineCode.value = highlightCode(inlineCodeExample, "vue");
-  highlightedWrapCode.value = highlightCode(wrapCodeExample, "vue");
 }
 
 watch(installCommand, () => {

--- a/packages/website/src/CodeBlock.vue
+++ b/packages/website/src/CodeBlock.vue
@@ -1,10 +1,7 @@
 <script setup lang="ts">
 import { computed, onBeforeUnmount, ref } from "vue";
 import { Check, Copy, X } from "@lucide/vue";
-import {
-  horizontalOverlayScrollbarsOptions,
-  overlayScrollbarsDirective,
-} from "./overlayScrollbars";
+import { overlayScrollbarsDirective } from "./overlayScrollbars";
 
 const props = withDefaults(
   defineProps<{
@@ -23,7 +20,6 @@ const props = withDefaults(
 type CopyState = "idle" | "copied" | "failed";
 
 const vOverlayScrollbars = overlayScrollbarsDirective;
-const horizontalOverlayScrollbars = horizontalOverlayScrollbarsOptions;
 
 const copyState = ref<CopyState>("idle");
 let resetTimer: number | undefined;
@@ -119,7 +115,7 @@ onBeforeUnmount(() => {
       <X v-else class="copy-icon" :size="14" aria-hidden="true" />
       <span class="sr-only">{{ buttonText.label }}</span>
     </button>
-    <div v-overlay-scrollbars="horizontalOverlayScrollbars" class="code-scroll" data-code-scroll>
+    <div v-overlay-scrollbars.x class="code-scroll" data-code-scroll>
       <div v-if="html" class="shiki-wrap" v-html="html" />
       <pre v-else class="code-block"><code>{{ code }}</code></pre>
     </div>

--- a/packages/website/src/FpsMeter.vue
+++ b/packages/website/src/FpsMeter.vue
@@ -1,0 +1,80 @@
+<script setup lang="ts">
+import { onBeforeUnmount, onMounted, ref } from "vue";
+import Stats from "stats.js";
+
+const hostRef = ref<HTMLElement | null>(null);
+let animationFrameId: number | null = null;
+let stats: Stats | null = null;
+
+function stop(): void {
+  if (animationFrameId !== null) {
+    cancelAnimationFrame(animationFrameId);
+    animationFrameId = null;
+  }
+}
+
+onMounted(() => {
+  const host = hostRef.value;
+  if (!host) {
+    return;
+  }
+
+  stats = new Stats();
+  stats.showPanel(0);
+  Object.assign(stats.dom.style, {
+    cursor: "default",
+    left: "auto",
+    opacity: "1",
+    pointerEvents: "none",
+    position: "relative",
+    top: "auto",
+    zIndex: "auto",
+  });
+  host.replaceChildren(stats.dom);
+
+  const update = () => {
+    stats?.update();
+    animationFrameId = requestAnimationFrame(update);
+  };
+
+  animationFrameId = requestAnimationFrame(update);
+});
+
+onBeforeUnmount(() => {
+  stop();
+  stats?.dom.remove();
+  stats = null;
+});
+</script>
+
+<template>
+  <div
+    ref="hostRef"
+    class="fps-meter-panel"
+    data-fps-meter
+    role="img"
+    aria-label="FPS monitor"
+  ></div>
+</template>
+
+<style scoped>
+.fps-meter-panel {
+  display: grid;
+  place-items: center;
+  overflow: hidden;
+  inline-size: 80px;
+  block-size: 48px;
+  border-radius: 6px;
+  background: #020617;
+  pointer-events: none;
+}
+
+.fps-meter-panel :deep(div) {
+  overflow: hidden;
+  border-radius: 6px;
+}
+
+.fps-meter-panel :deep(canvas) {
+  display: block;
+}
+</style>

--- a/packages/website/src/StressPlayground.vue
+++ b/packages/website/src/StressPlayground.vue
@@ -4,7 +4,7 @@ import { X } from "@lucide/vue";
 import { InlineClamp, LineClamp, RichLineClamp, WrapClamp } from "vue-clamp";
 import FpsMeter from "./FpsMeter.vue";
 import { lockPageScroll, trapDialogFocus } from "./modal";
-import { overlayScrollbarsDirective, verticalOverlayScrollbarsOptions } from "./overlayScrollbars";
+import { overlayScrollbarsDirective } from "./overlayScrollbars";
 
 type StressSurface = "line" | "rich" | "inline" | "wrap";
 type StressLimitKind = "height" | "lines";
@@ -43,7 +43,6 @@ const emit = defineEmits<{
 }>();
 
 const vOverlayScrollbars = overlayScrollbarsDirective;
-const verticalOverlayScrollbars = verticalOverlayScrollbarsOptions;
 const closeButtonRef = ref<HTMLButtonElement | null>(null);
 const dialogRef = ref<HTMLElement | null>(null);
 const selectedSurface = ref<StressSurface>(props.initialSurface);
@@ -271,11 +270,7 @@ onBeforeUnmount(() => {
         aria-modal="true"
         aria-labelledby="stress-playground-title"
       >
-        <div
-          v-overlay-scrollbars="verticalOverlayScrollbars"
-          class="stress-modal-scroll"
-          data-stress-modal-scroll
-        >
+        <div v-overlay-scrollbars.y class="stress-modal-scroll" data-stress-modal-scroll>
           <header class="stress-header">
             <div class="stress-title-group">
               <div class="stress-title-row">
@@ -459,7 +454,7 @@ onBeforeUnmount(() => {
             </div>
 
             <div
-              v-overlay-scrollbars="verticalOverlayScrollbars"
+              v-overlay-scrollbars.y
               class="stress-workload"
               data-stress-workload
               :style="sharedWidthStyle"

--- a/packages/website/src/StressPlayground.vue
+++ b/packages/website/src/StressPlayground.vue
@@ -548,12 +548,9 @@ onBeforeUnmount(() => {
                         <span
                           v-if="showAfterSlot"
                           class="stress-token stress-token-summary"
-                          :class="{ 'stress-token-summary--placeholder': hiddenItems.length === 0 }"
-                          :aria-hidden="hiddenItems.length === 0 ? 'true' : undefined"
-                          :data-stress-after-placeholder="hiddenItems.length === 0 ? '' : undefined"
-                          :data-stress-after-slot="hiddenItems.length > 0 ? '' : undefined"
+                          data-stress-after-slot
                         >
-                          +{{ Math.max(1, hiddenItems.length) }}
+                          {{ hiddenItems.length > 0 ? `+${hiddenItems.length}` : "Action" }}
                         </span>
                       </template>
                     </WrapClamp>
@@ -571,12 +568,9 @@ onBeforeUnmount(() => {
                         <span
                           v-if="showAfterSlot"
                           class="stress-token stress-token-summary"
-                          :class="{ 'stress-token-summary--placeholder': hiddenItems.length === 0 }"
-                          :aria-hidden="hiddenItems.length === 0 ? 'true' : undefined"
-                          :data-stress-after-placeholder="hiddenItems.length === 0 ? '' : undefined"
-                          :data-stress-after-slot="hiddenItems.length > 0 ? '' : undefined"
+                          data-stress-after-slot
                         >
-                          +{{ Math.max(1, hiddenItems.length) }}
+                          {{ hiddenItems.length > 0 ? `+${hiddenItems.length}` : "Action" }}
                         </span>
                       </template>
                     </WrapClamp>
@@ -996,11 +990,6 @@ onBeforeUnmount(() => {
   color: var(--c-accent-text);
   background: var(--c-accent-soft);
   border-color: color-mix(in srgb, var(--c-accent) 22%, transparent);
-}
-
-.stress-token-summary--placeholder {
-  visibility: hidden;
-  pointer-events: none;
 }
 
 @media (max-width: 899px) {

--- a/packages/website/src/StressPlayground.vue
+++ b/packages/website/src/StressPlayground.vue
@@ -47,7 +47,7 @@ const verticalOverlayScrollbars = verticalOverlayScrollbarsOptions;
 const closeButtonRef = ref<HTMLButtonElement | null>(null);
 const dialogRef = ref<HTMLElement | null>(null);
 const selectedSurface = ref<StressSurface>(props.initialSurface);
-const componentCountExponent = ref(1);
+const componentCount = ref(10);
 const sharedWidth = ref(360);
 const workloadScale = ref(3);
 const limitKind = ref<StressLimitKind>("lines");
@@ -106,10 +106,6 @@ watch(
   (surface) => {
     selectedSurface.value = surface;
   },
-);
-
-const componentCount = computed(() =>
-  Math.min(1000, Math.max(10, Math.round(10 ** componentCountExponent.value))),
 );
 
 const selectedSurfaceLabel = computed(
@@ -378,13 +374,13 @@ onBeforeUnmount(() => {
                   <span class="stress-control-label">Components</span>
                   <span class="stress-control-row">
                     <input
-                      v-model.number="componentCountExponent"
+                      v-model.number="componentCount"
                       data-stress-count-slider
                       class="stress-range"
                       type="range"
-                      min="1"
-                      max="3"
-                      step="0.01"
+                      min="10"
+                      max="200"
+                      step="1"
                     />
                     <span class="stress-value" data-stress-count>{{ componentCount }}</span>
                   </span>
@@ -552,9 +548,12 @@ onBeforeUnmount(() => {
                         <span
                           v-if="showAfterSlot"
                           class="stress-token stress-token-summary"
-                          data-stress-after-slot
+                          :class="{ 'stress-token-summary--placeholder': hiddenItems.length === 0 }"
+                          :aria-hidden="hiddenItems.length === 0 ? 'true' : undefined"
+                          :data-stress-after-placeholder="hiddenItems.length === 0 ? '' : undefined"
+                          :data-stress-after-slot="hiddenItems.length > 0 ? '' : undefined"
                         >
-                          +{{ hiddenItems.length }}
+                          +{{ Math.max(1, hiddenItems.length) }}
                         </span>
                       </template>
                     </WrapClamp>
@@ -572,9 +571,12 @@ onBeforeUnmount(() => {
                         <span
                           v-if="showAfterSlot"
                           class="stress-token stress-token-summary"
-                          data-stress-after-slot
+                          :class="{ 'stress-token-summary--placeholder': hiddenItems.length === 0 }"
+                          :aria-hidden="hiddenItems.length === 0 ? 'true' : undefined"
+                          :data-stress-after-placeholder="hiddenItems.length === 0 ? '' : undefined"
+                          :data-stress-after-slot="hiddenItems.length > 0 ? '' : undefined"
                         >
-                          +{{ hiddenItems.length }}
+                          +{{ Math.max(1, hiddenItems.length) }}
                         </span>
                       </template>
                     </WrapClamp>
@@ -656,6 +658,7 @@ onBeforeUnmount(() => {
 .stress-title-group p {
   margin: 2px 0 0;
   font-size: 0.78rem;
+  font-variant-numeric: tabular-nums;
   color: var(--c-text-3);
 }
 
@@ -971,6 +974,10 @@ onBeforeUnmount(() => {
   width: 100%;
 }
 
+.stress-wrap :deep([data-part="content"]) {
+  gap: 6px;
+}
+
 .stress-token {
   display: inline-flex;
   align-items: center;
@@ -985,9 +992,15 @@ onBeforeUnmount(() => {
 }
 
 .stress-token-summary {
+  font-variant-numeric: tabular-nums;
   color: var(--c-accent-text);
   background: var(--c-accent-soft);
   border-color: color-mix(in srgb, var(--c-accent) 22%, transparent);
+}
+
+.stress-token-summary--placeholder {
+  visibility: hidden;
+  pointer-events: none;
 }
 
 @media (max-width: 899px) {

--- a/packages/website/src/StressPlayground.vue
+++ b/packages/website/src/StressPlayground.vue
@@ -1,0 +1,1009 @@
+<script setup lang="ts">
+import { computed, onBeforeUnmount, onMounted, ref, watch } from "vue";
+import { X } from "@lucide/vue";
+import { InlineClamp, LineClamp, RichLineClamp, WrapClamp } from "vue-clamp";
+import FpsMeter from "./FpsMeter.vue";
+import { overlayScrollbarsDirective, verticalOverlayScrollbarsOptions } from "./overlayScrollbars";
+
+type StressSurface = "line" | "rich" | "inline" | "wrap";
+type StressLimitKind = "height" | "lines";
+type NativeClampStatus = {
+  feature: string;
+  mode: "single-line" | "multi-line";
+};
+
+type StressWrapItem = {
+  id: string;
+  label: string;
+};
+
+type StressItem = {
+  html: string;
+  id: number;
+  inlineText: string;
+  limitKind: StressLimitKind | "inline";
+  text: string;
+  wrapItems: StressWrapItem[];
+};
+
+const props = withDefaults(
+  defineProps<{
+    initialSurface?: StressSurface;
+  }>(),
+  {
+    initialSurface: "line",
+  },
+);
+
+const emit = defineEmits<{
+  close: [];
+}>();
+
+const vOverlayScrollbars = overlayScrollbarsDirective;
+const verticalOverlayScrollbars = verticalOverlayScrollbarsOptions;
+const closeButtonRef = ref<HTMLButtonElement | null>(null);
+const dialogRef = ref<HTMLElement | null>(null);
+const selectedSurface = ref<StressSurface>(props.initialSurface);
+const componentCountExponent = ref(1);
+const sharedWidth = ref(360);
+const workloadScale = ref(3);
+const limitKind = ref<StressLimitKind>("lines");
+const maxLines = ref(3);
+const maxHeight = ref(96);
+
+type ScrollLockSnapshot = {
+  bodyLeft: string;
+  bodyOverflow: string;
+  bodyPosition: string;
+  bodyRight: string;
+  bodyTop: string;
+  bodyWidth: string;
+  htmlOverflow: string;
+  scrollX: number;
+  scrollY: number;
+};
+
+let scrollLockSnapshot: ScrollLockSnapshot | null = null;
+
+const focusableSelector = [
+  "a[href]",
+  "button:not([disabled])",
+  "input:not([disabled])",
+  "select:not([disabled])",
+  "textarea:not([disabled])",
+  '[tabindex]:not([tabindex="-1"])',
+].join(",");
+
+const surfaceOptions = [
+  { label: "LineClamp", value: "line" },
+  { label: "RichLineClamp", value: "rich" },
+  { label: "InlineClamp", value: "inline" },
+  { label: "WrapClamp", value: "wrap" },
+] satisfies { label: string; value: StressSurface }[];
+
+const limitKindOptions = [
+  { label: "Lines", value: "lines" },
+  { label: "Height", value: "height" },
+] satisfies { label: string; value: StressLimitKind }[];
+
+const sampleTexts = [
+  "Vue Clamp keeps dense application text readable while preserving the full source text for assistive technology.",
+  "Resize the shared width to force every instance through the same layout change and watch the FPS meter while the browser settles.",
+  "Switch the active limit mode to exercise line-count or height-based clamping under synchronized layout changes.",
+  "A long localized sentence with punctuation, inline separators, and repeated words makes boundary decisions visible during resize.",
+  "Manual stress runs are useful for spotting jank that aggregate summaries can miss when many components update together.",
+  "The same payload is repeated across many component instances to make paint, layout, and clamp work easier to observe.",
+  "Controls intentionally update every rendered example at once, matching the way dense product screens often resize.",
+  "The stress playground favors fast iteration and visible feedback while many instances update together.",
+];
+
+const wrapLabels = [
+  "Design",
+  "Docs",
+  "Runtime",
+  "Testing",
+  "Accessibility",
+  "SSR",
+  "Hydration",
+  "Resize",
+  "Telemetry",
+  "Release",
+  "Content",
+  "I18n",
+  "Search",
+  "Navigation",
+  "Changelog",
+  "Review",
+];
+
+watch(
+  () => props.initialSurface,
+  (surface) => {
+    selectedSurface.value = surface;
+  },
+);
+
+const componentCount = computed(() =>
+  Math.min(1000, Math.max(10, Math.round(10 ** componentCountExponent.value))),
+);
+
+const selectedSurfaceLabel = computed(
+  () => surfaceOptions.find((option) => option.value === selectedSurface.value)?.label ?? "",
+);
+
+const textRepeatCount = computed(() => workloadScale.value);
+const wrapItemCount = computed(() => workloadScale.value * 8);
+const workloadDescription = computed(() =>
+  selectedSurface.value === "wrap"
+    ? `${wrapItemCount.value} items`
+    : `${textRepeatCount.value}x text`,
+);
+const hasLimitControls = computed(() => selectedSurface.value !== "inline");
+const nativeClampStatus = computed<NativeClampStatus | null>(() => {
+  if (selectedSurface.value !== "line" || limitKind.value !== "lines") {
+    return null;
+  }
+
+  if (maxLines.value === 1) {
+    return {
+      feature: "text-overflow",
+      mode: "single-line",
+    };
+  }
+
+  if (maxLines.value > 1 && supportsNativeLineClamp()) {
+    return {
+      feature: "line-clamp",
+      mode: "multi-line",
+    };
+  }
+
+  return null;
+});
+
+const stressItems = computed<StressItem[]>(() =>
+  Array.from({ length: componentCount.value }, (_, index) => stressItemFor(index)),
+);
+
+const sharedWidthStyle = computed(() => ({
+  "--stress-width": `${sharedWidth.value}px`,
+}));
+
+function stressItemFor(index: number): StressItem {
+  const surface = selectedSurface.value;
+  const item: StressItem = {
+    html: "",
+    id: index,
+    inlineText: "",
+    limitKind: surface === "inline" ? "inline" : limitKind.value,
+    text: "",
+    wrapItems: [],
+  };
+
+  switch (surface) {
+    case "rich":
+      item.html = richHtmlFor(index);
+      break;
+    case "inline":
+      item.inlineText = inlineTextFor(index);
+      break;
+    case "wrap":
+      item.wrapItems = wrapItemsFor(index);
+      break;
+    default:
+      item.text = textFor(index);
+  }
+
+  return item;
+}
+
+function textFor(index: number): string {
+  const segments: string[] = [];
+
+  for (let offset = 0; offset < textRepeatCount.value; offset += 1) {
+    segments.push(sampleTexts[(index + offset) % sampleTexts.length]!);
+  }
+
+  return `${index + 1}. ${segments.join(" ")}`;
+}
+
+function richHtmlFor(index: number): string {
+  const segments: string[] = [];
+
+  for (let offset = 0; offset < textRepeatCount.value; offset += 1) {
+    const text = sampleTexts[(index + offset) % sampleTexts.length]!;
+    const label = wrapLabels[(index + offset) % wrapLabels.length]!;
+    segments.push(
+      `<strong>${label}</strong> ${text} <em>Measured inline flow</em> keeps <code>code</code>, <a href="#components">links</a>, and marked fragments in one trusted HTML payload.`,
+    );
+  }
+
+  return `${index + 1}. ${segments.join(" ")}`;
+}
+
+function inlineTextFor(index: number): string {
+  const parts: string[] = [];
+
+  for (let offset = 0; offset < textRepeatCount.value; offset += 1) {
+    const label = wrapLabels[(index + offset) % wrapLabels.length]!.toLowerCase();
+    parts.push(`${label}/component-${index + 1}-${offset + 1}.vue`);
+  }
+
+  return `/workspace/vue-clamp/${parts.join("/")}#${sampleTexts[index % sampleTexts.length]}`;
+}
+
+function wrapItemsFor(index: number): StressWrapItem[] {
+  return Array.from({ length: wrapItemCount.value }, (_, itemIndex) => {
+    const label = wrapLabels[(index + itemIndex) % wrapLabels.length]!;
+
+    return {
+      id: `${index}-${itemIndex}`,
+      label: `${label} ${itemIndex + 1}`,
+    };
+  });
+}
+
+function supportsNativeLineClamp(): boolean {
+  if (typeof CSS === "undefined" || typeof CSS.supports !== "function") {
+    return false;
+  }
+
+  return CSS.supports("-webkit-line-clamp", "2") || CSS.supports("line-clamp", "2");
+}
+
+function close(): void {
+  emit("close");
+}
+
+function handleKeydown(event: KeyboardEvent): void {
+  if (event.key === "Escape") {
+    event.preventDefault();
+    close();
+    return;
+  }
+
+  if (event.key !== "Tab") {
+    return;
+  }
+
+  const dialog = dialogRef.value;
+  if (!dialog) {
+    return;
+  }
+
+  const focusableElements = Array.from(dialog.querySelectorAll<HTMLElement>(focusableSelector));
+  const firstElement = focusableElements[0] ?? closeButtonRef.value;
+  const lastElement = focusableElements.at(-1) ?? firstElement;
+  const activeElement = document.activeElement;
+
+  if (!firstElement || !lastElement) {
+    event.preventDefault();
+    return;
+  }
+
+  if (!dialog.contains(activeElement)) {
+    event.preventDefault();
+    firstElement.focus();
+    return;
+  }
+
+  if (event.shiftKey && activeElement === firstElement) {
+    event.preventDefault();
+    lastElement.focus();
+    return;
+  }
+
+  if (!event.shiftKey && activeElement === lastElement) {
+    event.preventDefault();
+    firstElement.focus();
+  }
+}
+
+function lockPageScroll(): void {
+  if (scrollLockSnapshot) {
+    return;
+  }
+
+  const { body, documentElement } = document;
+  scrollLockSnapshot = {
+    bodyLeft: body.style.left,
+    bodyOverflow: body.style.overflow,
+    bodyPosition: body.style.position,
+    bodyRight: body.style.right,
+    bodyTop: body.style.top,
+    bodyWidth: body.style.width,
+    htmlOverflow: documentElement.style.overflow,
+    scrollX: window.scrollX,
+    scrollY: window.scrollY,
+  };
+
+  documentElement.style.overflow = "hidden";
+  body.style.overflow = "hidden";
+  body.style.position = "fixed";
+  body.style.top = `-${scrollLockSnapshot.scrollY}px`;
+  body.style.left = `-${scrollLockSnapshot.scrollX}px`;
+  body.style.right = "0";
+  body.style.width = "100%";
+}
+
+function unlockPageScroll(): void {
+  if (!scrollLockSnapshot) {
+    return;
+  }
+
+  const { body, documentElement } = document;
+  const { scrollX, scrollY } = scrollLockSnapshot;
+
+  documentElement.style.overflow = scrollLockSnapshot.htmlOverflow;
+  body.style.overflow = scrollLockSnapshot.bodyOverflow;
+  body.style.position = scrollLockSnapshot.bodyPosition;
+  body.style.top = scrollLockSnapshot.bodyTop;
+  body.style.left = scrollLockSnapshot.bodyLeft;
+  body.style.right = scrollLockSnapshot.bodyRight;
+  body.style.width = scrollLockSnapshot.bodyWidth;
+  scrollLockSnapshot = null;
+
+  window.scrollTo(scrollX, scrollY);
+}
+
+onMounted(() => {
+  lockPageScroll();
+  window.addEventListener("keydown", handleKeydown);
+  closeButtonRef.value?.focus();
+});
+
+onBeforeUnmount(() => {
+  unlockPageScroll();
+  window.removeEventListener("keydown", handleKeydown);
+});
+</script>
+
+<template>
+  <Teleport to="body">
+    <div class="stress-overlay" data-stress-playground role="presentation" @click.self="close">
+      <section
+        ref="dialogRef"
+        class="stress-dialog"
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="stress-playground-title"
+      >
+        <div
+          v-overlay-scrollbars="verticalOverlayScrollbars"
+          class="stress-modal-scroll"
+          data-stress-modal-scroll
+        >
+          <header class="stress-header">
+            <div class="stress-title-group">
+              <div class="stress-title-row">
+                <h3 id="stress-playground-title">Stress playground</h3>
+                <span
+                  v-if="nativeClampStatus"
+                  class="stress-native-marker"
+                  data-stress-native-status
+                  :data-stress-native-mode="nativeClampStatus.mode"
+                  :aria-label="`Native CSS ${nativeClampStatus.feature}`"
+                  :title="`Native CSS ${nativeClampStatus.feature}`"
+                >
+                  Native
+                </span>
+              </div>
+              <p>
+                {{ selectedSurfaceLabel }} · {{ componentCount }} components ·
+                {{ workloadDescription }} · {{ sharedWidth }}px shared width
+              </p>
+            </div>
+            <div class="stress-header-tools">
+              <div class="stress-meter">
+                <span class="stress-meter-label">Live</span>
+                <FpsMeter class="stress-fps" />
+              </div>
+              <button
+                ref="closeButtonRef"
+                class="stress-close"
+                data-stress-close
+                type="button"
+                aria-label="Close stress playground"
+                @click="close"
+              >
+                <X :size="18" :stroke-width="2" aria-hidden="true" />
+              </button>
+            </div>
+          </header>
+
+          <div class="stress-controls">
+            <div class="stress-control stress-surface-control">
+              <span class="stress-control-label">Component</span>
+              <span class="stress-surface-options" role="group" aria-label="Stress component">
+                <button
+                  v-for="option in surfaceOptions"
+                  :key="option.value"
+                  class="stress-surface-option"
+                  :class="{ active: selectedSurface === option.value }"
+                  :data-stress-surface="option.value"
+                  type="button"
+                  :aria-pressed="selectedSurface === option.value"
+                  @click="selectedSurface = option.value"
+                >
+                  {{ option.label }}
+                </button>
+              </span>
+            </div>
+
+            <label class="stress-control">
+              <span class="stress-control-label">Components</span>
+              <span class="stress-control-row">
+                <input
+                  v-model.number="componentCountExponent"
+                  data-stress-count-slider
+                  class="stress-range"
+                  type="range"
+                  min="1"
+                  max="3"
+                  step="0.01"
+                />
+                <span class="stress-value" data-stress-count>{{ componentCount }}</span>
+              </span>
+            </label>
+
+            <label class="stress-control">
+              <span class="stress-control-label">Width</span>
+              <span class="stress-control-row">
+                <input
+                  v-model.number="sharedWidth"
+                  data-stress-width-slider
+                  class="stress-range"
+                  type="range"
+                  min="180"
+                  max="720"
+                  step="4"
+                />
+                <span class="stress-value" data-stress-width>{{ sharedWidth }}px</span>
+              </span>
+            </label>
+
+            <label class="stress-control">
+              <span class="stress-control-label">{{
+                selectedSurface === "wrap" ? "Item count" : "Text length"
+              }}</span>
+              <span class="stress-control-row">
+                <input
+                  v-model.number="workloadScale"
+                  data-stress-payload-slider
+                  class="stress-range"
+                  type="range"
+                  min="1"
+                  max="8"
+                  step="1"
+                />
+                <span class="stress-value" data-stress-payload>{{ workloadDescription }}</span>
+              </span>
+            </label>
+
+            <div v-if="hasLimitControls" class="stress-control">
+              <span class="stress-control-label">Limit</span>
+              <span class="stress-surface-options" role="group" aria-label="Stress limit mode">
+                <button
+                  v-for="option in limitKindOptions"
+                  :key="option.value"
+                  class="stress-surface-option"
+                  :class="{ active: limitKind === option.value }"
+                  :data-stress-limit-mode="option.value"
+                  type="button"
+                  :aria-pressed="limitKind === option.value"
+                  @click="limitKind = option.value"
+                >
+                  {{ option.label }}
+                </button>
+              </span>
+            </div>
+
+            <label v-if="hasLimitControls && limitKind === 'lines'" class="stress-control">
+              <span class="stress-control-label">Max lines</span>
+              <span class="stress-control-row">
+                <input
+                  v-model.number="maxLines"
+                  data-stress-max-lines-slider
+                  class="stress-range"
+                  type="range"
+                  min="1"
+                  max="8"
+                  step="1"
+                />
+                <span class="stress-value" data-stress-max-lines>{{ maxLines }}</span>
+              </span>
+            </label>
+
+            <label v-if="hasLimitControls && limitKind === 'height'" class="stress-control">
+              <span class="stress-control-label">Max height</span>
+              <span class="stress-control-row">
+                <input
+                  v-model.number="maxHeight"
+                  data-stress-max-height-slider
+                  class="stress-range"
+                  type="range"
+                  min="24"
+                  max="220"
+                  step="4"
+                />
+                <span class="stress-value" data-stress-max-height>{{ maxHeight }}px</span>
+              </span>
+            </label>
+          </div>
+
+          <div
+            v-overlay-scrollbars="verticalOverlayScrollbars"
+            class="stress-workload"
+            data-stress-workload
+            :style="sharedWidthStyle"
+          >
+            <div class="stress-list">
+              <article
+                v-for="item in stressItems"
+                :key="`${selectedSurface}-${item.id}`"
+                class="stress-item"
+                :data-stress-item="item.limitKind"
+                :data-stress-surface-item="selectedSurface"
+              >
+                <span class="stress-item-meta">
+                  {{ selectedSurfaceLabel }} · {{ item.limitKind }}
+                </span>
+
+                <template v-if="selectedSurface === 'line'">
+                  <LineClamp
+                    v-if="item.limitKind === 'lines'"
+                    class="stress-clamp"
+                    :text="item.text"
+                    :max-lines="maxLines"
+                  />
+                  <LineClamp
+                    v-else
+                    class="stress-clamp"
+                    :text="item.text"
+                    :max-height="maxHeight"
+                  />
+                </template>
+
+                <template v-else-if="selectedSurface === 'rich'">
+                  <RichLineClamp
+                    v-if="item.limitKind === 'lines'"
+                    class="stress-clamp stress-rich"
+                    :html="item.html"
+                    :max-lines="maxLines"
+                  />
+                  <RichLineClamp
+                    v-else
+                    class="stress-clamp stress-rich"
+                    :html="item.html"
+                    :max-height="maxHeight"
+                  />
+                </template>
+
+                <InlineClamp
+                  v-else-if="selectedSurface === 'inline'"
+                  class="stress-clamp stress-inline"
+                  :text="item.inlineText"
+                  location="middle"
+                />
+
+                <template v-else>
+                  <WrapClamp
+                    v-if="item.limitKind === 'lines'"
+                    class="stress-clamp stress-wrap"
+                    :items="item.wrapItems"
+                    item-key="id"
+                    :max-lines="maxLines"
+                  >
+                    <template #item="{ item: wrapItem }">
+                      <span class="stress-token">{{ wrapItem.label }}</span>
+                    </template>
+                    <template #after="{ hiddenItems }">
+                      <span class="stress-token stress-token-summary">
+                        +{{ hiddenItems.length }}
+                      </span>
+                    </template>
+                  </WrapClamp>
+                  <WrapClamp
+                    v-else
+                    class="stress-clamp stress-wrap"
+                    :items="item.wrapItems"
+                    item-key="id"
+                    :max-height="maxHeight"
+                  >
+                    <template #item="{ item: wrapItem }">
+                      <span class="stress-token">{{ wrapItem.label }}</span>
+                    </template>
+                    <template #after="{ hiddenItems }">
+                      <span class="stress-token stress-token-summary">
+                        +{{ hiddenItems.length }}
+                      </span>
+                    </template>
+                  </WrapClamp>
+                </template>
+              </article>
+            </div>
+          </div>
+        </div>
+      </section>
+    </div>
+  </Teleport>
+</template>
+
+<style scoped>
+.stress-overlay {
+  position: fixed;
+  inset: 0;
+  z-index: 90;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 22px;
+  background: color-mix(in srgb, #020617 42%, transparent);
+  backdrop-filter: blur(12px);
+}
+
+.stress-dialog {
+  --stress-dialog-block-size: calc(100svh - 44px);
+
+  overflow: hidden;
+  inline-size: min(1120px, 100%);
+  block-size: var(--stress-dialog-block-size);
+  background: var(--c-bg);
+  border: 1px solid color-mix(in srgb, var(--c-border) 84%, transparent);
+  border-radius: 14px;
+  box-shadow: 0 28px 80px color-mix(in srgb, #020617 28%, transparent);
+}
+
+.stress-modal-scroll {
+  block-size: 100%;
+  overflow: auto;
+}
+
+.stress-modal-scroll :deep([data-overlayscrollbars-viewport]) {
+  display: grid;
+  grid-template-rows: auto auto minmax(0, 1fr);
+  block-size: 100%;
+  overscroll-behavior: contain;
+}
+
+.stress-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 18px;
+  padding: 14px 16px;
+  border-bottom: 1px solid color-mix(in srgb, var(--c-border) 82%, transparent);
+}
+
+.stress-title-group {
+  min-width: 0;
+}
+
+.stress-title-row {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  min-width: 0;
+}
+
+.stress-title-group h3 {
+  margin: 0;
+  font-size: 1rem;
+  line-height: 1.3;
+  letter-spacing: 0;
+}
+
+.stress-title-group p {
+  margin: 2px 0 0;
+  font-size: 0.78rem;
+  color: var(--c-text-3);
+}
+
+.stress-header-tools {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+}
+
+.stress-meter {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 5px 8px;
+  background: color-mix(in srgb, var(--c-bg-soft) 72%, transparent);
+  border: 1px solid color-mix(in srgb, var(--c-border) 82%, transparent);
+  border-radius: 9px;
+}
+
+.stress-meter-label {
+  font-size: 0.7rem;
+  font-weight: 700;
+  line-height: 1;
+  color: var(--c-text-3);
+  text-transform: uppercase;
+  letter-spacing: 0;
+}
+
+.stress-fps {
+  flex: 0 0 auto;
+}
+
+.stress-close {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  flex: 0 0 34px;
+  inline-size: 34px;
+  block-size: 34px;
+  color: var(--c-text-2);
+  background: transparent;
+  border: 1px solid transparent;
+  border-radius: 8px;
+  cursor: pointer;
+  transition:
+    background 0.15s,
+    border-color 0.15s,
+    color 0.15s;
+}
+
+.stress-close:hover {
+  color: var(--c-text);
+  background: var(--c-bg-mute);
+  border-color: var(--c-border);
+}
+
+.stress-close:focus-visible {
+  outline: none;
+  box-shadow: var(--focus-ring);
+}
+
+.stress-controls {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(190px, 1fr));
+  gap: 16px 28px;
+  padding: 14px 16px;
+  background: color-mix(in srgb, var(--c-bg-soft) 64%, transparent);
+  border-bottom: 1px solid color-mix(in srgb, var(--c-border) 82%, transparent);
+}
+
+.stress-control {
+  display: grid;
+  gap: 7px;
+  min-width: 0;
+}
+
+.stress-surface-control {
+  grid-column: 1 / -1;
+}
+
+.stress-control-label {
+  font-size: 0.73rem;
+  font-weight: 600;
+  line-height: 1.2;
+  color: var(--c-text-3);
+  text-transform: uppercase;
+  letter-spacing: 0;
+}
+
+.stress-control-row {
+  display: flex;
+  align-items: center;
+  min-width: 0;
+  gap: 7px;
+}
+
+.stress-surface-options {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+}
+
+.stress-surface-option {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 28px;
+  padding: 0 10px;
+  font-size: 0.76rem;
+  font-weight: 600;
+  font-family: inherit;
+  color: var(--c-text-2);
+  background: var(--c-bg);
+  border: 1px solid var(--c-border);
+  border-radius: 7px;
+  cursor: pointer;
+  transition:
+    background 0.15s,
+    border-color 0.15s,
+    color 0.15s;
+}
+
+.stress-surface-option:hover {
+  color: var(--c-text);
+  border-color: var(--c-border-dark);
+}
+
+.stress-surface-option.active,
+.stress-surface-option[aria-pressed="true"] {
+  color: var(--c-accent-text);
+  background: var(--c-accent-soft);
+  border-color: color-mix(in srgb, var(--c-accent) 24%, transparent);
+}
+
+.stress-surface-option:focus-visible {
+  outline: none;
+  box-shadow: var(--focus-ring);
+}
+
+.stress-range {
+  flex: 1 1 auto;
+  min-width: 96px;
+  height: 4px;
+  appearance: none;
+  background: var(--c-bg-mute);
+  border-radius: 2px;
+  cursor: pointer;
+}
+
+.stress-range:focus-visible {
+  outline: none;
+  box-shadow: var(--focus-ring);
+}
+
+.stress-range::-webkit-slider-thumb {
+  appearance: none;
+  inline-size: 14px;
+  block-size: 14px;
+  background: var(--c-accent);
+  border: 2px solid var(--c-bg);
+  border-radius: 50%;
+  box-shadow: 0 0 0 1px var(--c-border-dark);
+}
+
+.stress-value {
+  flex: 0 0 auto;
+  min-width: 2.5ch;
+  font-family: var(--font-mono);
+  font-size: 0.78rem;
+  line-height: 1;
+  color: var(--c-text);
+}
+
+.stress-native-marker {
+  display: inline-flex;
+  align-items: center;
+  flex: 0 0 auto;
+  min-height: 18px;
+  padding: 0 6px;
+  font-size: 0.62rem;
+  font-weight: 700;
+  line-height: 1;
+  color: var(--c-accent-text);
+  background: var(--c-accent-soft);
+  border: 1px solid color-mix(in srgb, var(--c-accent) 22%, transparent);
+  border-radius: 999px;
+  letter-spacing: 0;
+  text-transform: uppercase;
+}
+
+.stress-workload {
+  overflow: auto;
+  min-block-size: 0;
+  padding: 14px 16px 18px;
+}
+
+.stress-workload :deep([data-overlayscrollbars-viewport]) {
+  overscroll-behavior: contain;
+}
+
+.stress-list {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: flex-start;
+  gap: 8px;
+}
+
+.stress-item {
+  position: relative;
+  display: grid;
+  gap: 5px;
+  flex: 0 0 min(100%, var(--stress-width));
+  padding: 8px 10px;
+  background: var(--c-bg);
+  border: 1px solid color-mix(in srgb, var(--c-border) 78%, transparent);
+  border-radius: 7px;
+}
+
+.stress-item-meta {
+  font-family: var(--font-mono);
+  font-size: 0.64rem;
+  font-weight: 600;
+  line-height: 1;
+  color: var(--c-text-3);
+  text-transform: uppercase;
+  letter-spacing: 0;
+}
+
+.stress-clamp {
+  display: block;
+  max-width: 100%;
+  font-size: 0.82rem;
+  line-height: 1.45;
+  color: var(--c-text);
+}
+
+.stress-rich :deep(code) {
+  padding: 0 0.2em;
+  background: var(--c-code-bg);
+  border-radius: 4px;
+}
+
+.stress-inline {
+  width: 100%;
+}
+
+.stress-wrap {
+  width: 100%;
+}
+
+.stress-token {
+  display: inline-flex;
+  align-items: center;
+  min-height: 22px;
+  padding: 0 7px;
+  font-size: 0.76rem;
+  line-height: 1;
+  color: var(--c-text-2);
+  background: var(--c-bg-soft);
+  border: 1px solid var(--c-border);
+  border-radius: 999px;
+}
+
+.stress-token-summary {
+  color: var(--c-accent-text);
+  background: var(--c-accent-soft);
+  border-color: color-mix(in srgb, var(--c-accent) 22%, transparent);
+}
+
+@media (max-width: 639px) {
+  .stress-overlay {
+    align-items: stretch;
+    padding: 0;
+  }
+
+  .stress-dialog {
+    inline-size: 100%;
+    block-size: 100svh;
+    border: none;
+    border-radius: 0;
+  }
+
+  .stress-header {
+    align-items: flex-start;
+    padding: max(12px, env(safe-area-inset-top)) 12px 12px;
+  }
+
+  .stress-header-tools {
+    gap: 8px;
+  }
+
+  .stress-meter {
+    padding: 4px 6px;
+    gap: 6px;
+  }
+
+  .stress-meter-label {
+    display: none;
+  }
+
+  .stress-controls {
+    grid-template-columns: 1fr;
+    gap: 10px;
+    padding: 12px;
+  }
+
+  .stress-workload {
+    padding: 12px 12px max(18px, env(safe-area-inset-bottom));
+  }
+}
+</style>

--- a/packages/website/src/StressPlayground.vue
+++ b/packages/website/src/StressPlayground.vue
@@ -3,6 +3,7 @@ import { computed, onBeforeUnmount, onMounted, ref, watch } from "vue";
 import { X } from "@lucide/vue";
 import { InlineClamp, LineClamp, RichLineClamp, WrapClamp } from "vue-clamp";
 import FpsMeter from "./FpsMeter.vue";
+import { lockPageScroll, trapDialogFocus } from "./modal";
 import { overlayScrollbarsDirective, verticalOverlayScrollbarsOptions } from "./overlayScrollbars";
 
 type StressSurface = "line" | "rich" | "inline" | "wrap";
@@ -29,9 +30,11 @@ type StressItem = {
 const props = withDefaults(
   defineProps<{
     initialSurface?: StressSurface;
+    returnFocusTo?: HTMLElement | null;
   }>(),
   {
     initialSurface: "line",
+    returnFocusTo: null,
   },
 );
 
@@ -52,28 +55,9 @@ const maxLines = ref(3);
 const maxHeight = ref(96);
 const showAfterSlot = ref(false);
 
-type ScrollLockSnapshot = {
-  bodyLeft: string;
-  bodyOverflow: string;
-  bodyPosition: string;
-  bodyRight: string;
-  bodyTop: string;
-  bodyWidth: string;
-  htmlOverflow: string;
-  scrollX: number;
-  scrollY: number;
-};
+function noop(): void {}
 
-let scrollLockSnapshot: ScrollLockSnapshot | null = null;
-
-const focusableSelector = [
-  "a[href]",
-  "button:not([disabled])",
-  "input:not([disabled])",
-  "select:not([disabled])",
-  "textarea:not([disabled])",
-  '[tabindex]:not([tabindex="-1"])',
-].join(",");
+let releaseModal = noop;
 
 const surfaceOptions = [
   { label: "LineClamp", value: "line" },
@@ -257,106 +241,23 @@ function close(): void {
   emit("close");
 }
 
-function handleKeydown(event: KeyboardEvent): void {
-  if (event.key === "Escape") {
-    event.preventDefault();
-    close();
-    return;
-  }
-
-  if (event.key !== "Tab") {
-    return;
-  }
-
-  const dialog = dialogRef.value;
-  if (!dialog) {
-    return;
-  }
-
-  const focusableElements = Array.from(dialog.querySelectorAll<HTMLElement>(focusableSelector));
-  const firstElement = focusableElements[0] ?? closeButtonRef.value;
-  const lastElement = focusableElements.at(-1) ?? firstElement;
-  const activeElement = document.activeElement;
-
-  if (!firstElement || !lastElement) {
-    event.preventDefault();
-    return;
-  }
-
-  if (!dialog.contains(activeElement)) {
-    event.preventDefault();
-    firstElement.focus();
-    return;
-  }
-
-  if (event.shiftKey && activeElement === firstElement) {
-    event.preventDefault();
-    lastElement.focus();
-    return;
-  }
-
-  if (!event.shiftKey && activeElement === lastElement) {
-    event.preventDefault();
-    firstElement.focus();
-  }
-}
-
-function lockPageScroll(): void {
-  if (scrollLockSnapshot) {
-    return;
-  }
-
-  const { body, documentElement } = document;
-  scrollLockSnapshot = {
-    bodyLeft: body.style.left,
-    bodyOverflow: body.style.overflow,
-    bodyPosition: body.style.position,
-    bodyRight: body.style.right,
-    bodyTop: body.style.top,
-    bodyWidth: body.style.width,
-    htmlOverflow: documentElement.style.overflow,
-    scrollX: window.scrollX,
-    scrollY: window.scrollY,
-  };
-
-  documentElement.style.overflow = "hidden";
-  body.style.overflow = "hidden";
-  body.style.position = "fixed";
-  body.style.top = `-${scrollLockSnapshot.scrollY}px`;
-  body.style.left = `-${scrollLockSnapshot.scrollX}px`;
-  body.style.right = "0";
-  body.style.width = "100%";
-}
-
-function unlockPageScroll(): void {
-  if (!scrollLockSnapshot) {
-    return;
-  }
-
-  const { body, documentElement } = document;
-  const { scrollX, scrollY } = scrollLockSnapshot;
-
-  documentElement.style.overflow = scrollLockSnapshot.htmlOverflow;
-  body.style.overflow = scrollLockSnapshot.bodyOverflow;
-  body.style.position = scrollLockSnapshot.bodyPosition;
-  body.style.top = scrollLockSnapshot.bodyTop;
-  body.style.left = scrollLockSnapshot.bodyLeft;
-  body.style.right = scrollLockSnapshot.bodyRight;
-  body.style.width = scrollLockSnapshot.bodyWidth;
-  scrollLockSnapshot = null;
-
-  window.scrollTo(scrollX, scrollY);
-}
-
 onMounted(() => {
-  lockPageScroll();
-  window.addEventListener("keydown", handleKeydown);
-  closeButtonRef.value?.focus();
+  const unlockScroll = lockPageScroll();
+  const releaseFocus = trapDialogFocus({
+    getDialog: () => dialogRef.value,
+    getInitialFocus: () => closeButtonRef.value,
+    getRestoreFocus: () => props.returnFocusTo ?? null,
+    onEscape: close,
+  });
+
+  releaseModal = function releaseStressModal(): void {
+    releaseFocus();
+    unlockScroll();
+  };
 });
 
 onBeforeUnmount(() => {
-  unlockPageScroll();
-  window.removeEventListener("keydown", handleKeydown);
+  releaseModal();
 });
 </script>
 

--- a/packages/website/src/StressPlayground.vue
+++ b/packages/website/src/StressPlayground.vue
@@ -225,6 +225,10 @@ function wrapItemsFor(index: number): StressWrapItem[] {
   });
 }
 
+function wrapAfterLabel(hiddenItems: readonly unknown[]): string {
+  return hiddenItems.length > 0 ? `+${hiddenItems.length}` : "Action";
+}
+
 function supportsNativeLineClamp(): boolean {
   if (typeof CSS === "undefined" || typeof CSS.supports !== "function") {
     return false;
@@ -550,7 +554,7 @@ onBeforeUnmount(() => {
                           class="stress-token stress-token-summary"
                           data-stress-after-slot
                         >
-                          {{ hiddenItems.length > 0 ? `+${hiddenItems.length}` : "Action" }}
+                          {{ wrapAfterLabel(hiddenItems) }}
                         </span>
                       </template>
                     </WrapClamp>
@@ -570,7 +574,7 @@ onBeforeUnmount(() => {
                           class="stress-token stress-token-summary"
                           data-stress-after-slot
                         >
-                          {{ hiddenItems.length > 0 ? `+${hiddenItems.length}` : "Action" }}
+                          {{ wrapAfterLabel(hiddenItems) }}
                         </span>
                       </template>
                     </WrapClamp>

--- a/packages/website/src/StressPlayground.vue
+++ b/packages/website/src/StressPlayground.vue
@@ -50,6 +50,7 @@ const workloadScale = ref(3);
 const limitKind = ref<StressLimitKind>("lines");
 const maxLines = ref(3);
 const maxHeight = ref(96);
+const showAfterSlot = ref(false);
 
 type ScrollLockSnapshot = {
   bodyLeft: string;
@@ -139,6 +140,7 @@ const workloadDescription = computed(() =>
     : `${textRepeatCount.value}x text`,
 );
 const hasLimitControls = computed(() => selectedSurface.value !== "inline");
+const supportsAfterSlot = computed(() => selectedSurface.value !== "inline");
 const nativeClampStatus = computed<NativeClampStatus | null>(() => {
   if (selectedSurface.value !== "line" || limitKind.value !== "lines") {
     return null;
@@ -151,7 +153,7 @@ const nativeClampStatus = computed<NativeClampStatus | null>(() => {
     };
   }
 
-  if (maxLines.value > 1 && supportsNativeLineClamp()) {
+  if (maxLines.value > 1 && !showAfterSlot.value && supportsNativeLineClamp()) {
     return {
       feature: "line-clamp",
       mode: "multi-line",
@@ -411,216 +413,273 @@ onBeforeUnmount(() => {
             </div>
           </header>
 
-          <div class="stress-controls">
-            <div class="stress-control stress-surface-control">
-              <span class="stress-control-label">Component</span>
-              <span class="stress-surface-options" role="group" aria-label="Stress component">
-                <button
-                  v-for="option in surfaceOptions"
-                  :key="option.value"
-                  class="stress-surface-option"
-                  :class="{ active: selectedSurface === option.value }"
-                  :data-stress-surface="option.value"
-                  type="button"
-                  :aria-pressed="selectedSurface === option.value"
-                  @click="selectedSurface = option.value"
-                >
-                  {{ option.label }}
-                </button>
-              </span>
+          <div class="stress-body">
+            <div class="stress-controls">
+              <div class="stress-control-band stress-mode-band">
+                <div class="stress-control stress-component-control">
+                  <span class="stress-control-label">Component</span>
+                  <span class="stress-surface-options" role="group" aria-label="Stress component">
+                    <button
+                      v-for="option in surfaceOptions"
+                      :key="option.value"
+                      class="stress-surface-option"
+                      :class="{ active: selectedSurface === option.value }"
+                      :data-stress-surface="option.value"
+                      type="button"
+                      :aria-pressed="selectedSurface === option.value"
+                      @click="selectedSurface = option.value"
+                    >
+                      {{ option.label }}
+                    </button>
+                  </span>
+                </div>
+
+                <div v-if="hasLimitControls" class="stress-control stress-limit-control">
+                  <span class="stress-control-label">Limit</span>
+                  <span class="stress-surface-options" role="group" aria-label="Stress limit mode">
+                    <button
+                      v-for="option in limitKindOptions"
+                      :key="option.value"
+                      class="stress-surface-option"
+                      :class="{ active: limitKind === option.value }"
+                      :data-stress-limit-mode="option.value"
+                      type="button"
+                      :aria-pressed="limitKind === option.value"
+                      @click="limitKind = option.value"
+                    >
+                      {{ option.label }}
+                    </button>
+                  </span>
+                </div>
+
+                <label v-if="supportsAfterSlot" class="stress-control stress-slot-control">
+                  <span class="stress-control-label">Slots</span>
+                  <span class="stress-toggle-row">
+                    <input
+                      v-model="showAfterSlot"
+                      data-stress-after-toggle
+                      class="stress-checkbox"
+                      type="checkbox"
+                    />
+                    <span
+                      class="stress-toggle-value"
+                      data-stress-after-state
+                      :data-enabled="showAfterSlot ? 'true' : 'false'"
+                    >
+                      After slot
+                    </span>
+                  </span>
+                </label>
+              </div>
+
+              <div class="stress-control-band stress-slider-band">
+                <label class="stress-control">
+                  <span class="stress-control-label">Components</span>
+                  <span class="stress-control-row">
+                    <input
+                      v-model.number="componentCountExponent"
+                      data-stress-count-slider
+                      class="stress-range"
+                      type="range"
+                      min="1"
+                      max="3"
+                      step="0.01"
+                    />
+                    <span class="stress-value" data-stress-count>{{ componentCount }}</span>
+                  </span>
+                </label>
+
+                <label class="stress-control">
+                  <span class="stress-control-label">{{
+                    selectedSurface === "wrap" ? "Item count" : "Text length"
+                  }}</span>
+                  <span class="stress-control-row">
+                    <input
+                      v-model.number="workloadScale"
+                      data-stress-payload-slider
+                      class="stress-range"
+                      type="range"
+                      min="1"
+                      max="8"
+                      step="1"
+                    />
+                    <span class="stress-value" data-stress-payload>{{ workloadDescription }}</span>
+                  </span>
+                </label>
+
+                <label class="stress-control">
+                  <span class="stress-control-label">Width</span>
+                  <span class="stress-control-row">
+                    <input
+                      v-model.number="sharedWidth"
+                      data-stress-width-slider
+                      class="stress-range"
+                      type="range"
+                      min="180"
+                      max="720"
+                      step="4"
+                    />
+                    <span class="stress-value" data-stress-width>{{ sharedWidth }}px</span>
+                  </span>
+                </label>
+
+                <label v-if="hasLimitControls && limitKind === 'lines'" class="stress-control">
+                  <span class="stress-control-label">Max lines</span>
+                  <span class="stress-control-row">
+                    <input
+                      v-model.number="maxLines"
+                      data-stress-max-lines-slider
+                      class="stress-range"
+                      type="range"
+                      min="1"
+                      max="8"
+                      step="1"
+                    />
+                    <span class="stress-value" data-stress-max-lines>{{ maxLines }}</span>
+                  </span>
+                </label>
+
+                <label v-if="hasLimitControls && limitKind === 'height'" class="stress-control">
+                  <span class="stress-control-label">Max height</span>
+                  <span class="stress-control-row">
+                    <input
+                      v-model.number="maxHeight"
+                      data-stress-max-height-slider
+                      class="stress-range"
+                      type="range"
+                      min="24"
+                      max="220"
+                      step="4"
+                    />
+                    <span class="stress-value" data-stress-max-height>{{ maxHeight }}px</span>
+                  </span>
+                </label>
+              </div>
             </div>
 
-            <label class="stress-control">
-              <span class="stress-control-label">Components</span>
-              <span class="stress-control-row">
-                <input
-                  v-model.number="componentCountExponent"
-                  data-stress-count-slider
-                  class="stress-range"
-                  type="range"
-                  min="1"
-                  max="3"
-                  step="0.01"
-                />
-                <span class="stress-value" data-stress-count>{{ componentCount }}</span>
-              </span>
-            </label>
-
-            <label class="stress-control">
-              <span class="stress-control-label">Width</span>
-              <span class="stress-control-row">
-                <input
-                  v-model.number="sharedWidth"
-                  data-stress-width-slider
-                  class="stress-range"
-                  type="range"
-                  min="180"
-                  max="720"
-                  step="4"
-                />
-                <span class="stress-value" data-stress-width>{{ sharedWidth }}px</span>
-              </span>
-            </label>
-
-            <label class="stress-control">
-              <span class="stress-control-label">{{
-                selectedSurface === "wrap" ? "Item count" : "Text length"
-              }}</span>
-              <span class="stress-control-row">
-                <input
-                  v-model.number="workloadScale"
-                  data-stress-payload-slider
-                  class="stress-range"
-                  type="range"
-                  min="1"
-                  max="8"
-                  step="1"
-                />
-                <span class="stress-value" data-stress-payload>{{ workloadDescription }}</span>
-              </span>
-            </label>
-
-            <div v-if="hasLimitControls" class="stress-control">
-              <span class="stress-control-label">Limit</span>
-              <span class="stress-surface-options" role="group" aria-label="Stress limit mode">
-                <button
-                  v-for="option in limitKindOptions"
-                  :key="option.value"
-                  class="stress-surface-option"
-                  :class="{ active: limitKind === option.value }"
-                  :data-stress-limit-mode="option.value"
-                  type="button"
-                  :aria-pressed="limitKind === option.value"
-                  @click="limitKind = option.value"
+            <div
+              v-overlay-scrollbars="verticalOverlayScrollbars"
+              class="stress-workload"
+              data-stress-workload
+              :style="sharedWidthStyle"
+            >
+              <div class="stress-list">
+                <article
+                  v-for="item in stressItems"
+                  :key="`${selectedSurface}-${item.id}`"
+                  class="stress-item"
+                  :data-stress-item="item.limitKind"
+                  :data-stress-surface-item="selectedSurface"
                 >
-                  {{ option.label }}
-                </button>
-              </span>
-            </div>
+                  <span class="stress-item-meta">
+                    {{ selectedSurfaceLabel }} · {{ item.limitKind }}
+                  </span>
 
-            <label v-if="hasLimitControls && limitKind === 'lines'" class="stress-control">
-              <span class="stress-control-label">Max lines</span>
-              <span class="stress-control-row">
-                <input
-                  v-model.number="maxLines"
-                  data-stress-max-lines-slider
-                  class="stress-range"
-                  type="range"
-                  min="1"
-                  max="8"
-                  step="1"
-                />
-                <span class="stress-value" data-stress-max-lines>{{ maxLines }}</span>
-              </span>
-            </label>
+                  <template v-if="selectedSurface === 'line'">
+                    <LineClamp
+                      v-if="item.limitKind === 'lines'"
+                      class="stress-clamp"
+                      :text="item.text"
+                      :max-lines="maxLines"
+                    >
+                      <template #after>
+                        <span v-if="showAfterSlot" class="stress-after-slot" data-stress-after-slot>
+                          After
+                        </span>
+                      </template>
+                    </LineClamp>
+                    <LineClamp
+                      v-else
+                      class="stress-clamp"
+                      :text="item.text"
+                      :max-height="maxHeight"
+                    >
+                      <template #after>
+                        <span v-if="showAfterSlot" class="stress-after-slot" data-stress-after-slot>
+                          After
+                        </span>
+                      </template>
+                    </LineClamp>
+                  </template>
 
-            <label v-if="hasLimitControls && limitKind === 'height'" class="stress-control">
-              <span class="stress-control-label">Max height</span>
-              <span class="stress-control-row">
-                <input
-                  v-model.number="maxHeight"
-                  data-stress-max-height-slider
-                  class="stress-range"
-                  type="range"
-                  min="24"
-                  max="220"
-                  step="4"
-                />
-                <span class="stress-value" data-stress-max-height>{{ maxHeight }}px</span>
-              </span>
-            </label>
-          </div>
+                  <template v-else-if="selectedSurface === 'rich'">
+                    <RichLineClamp
+                      v-if="item.limitKind === 'lines'"
+                      class="stress-clamp stress-rich"
+                      :html="item.html"
+                      :max-lines="maxLines"
+                    >
+                      <template #after>
+                        <span v-if="showAfterSlot" class="stress-after-slot" data-stress-after-slot>
+                          After
+                        </span>
+                      </template>
+                    </RichLineClamp>
+                    <RichLineClamp
+                      v-else
+                      class="stress-clamp stress-rich"
+                      :html="item.html"
+                      :max-height="maxHeight"
+                    >
+                      <template #after>
+                        <span v-if="showAfterSlot" class="stress-after-slot" data-stress-after-slot>
+                          After
+                        </span>
+                      </template>
+                    </RichLineClamp>
+                  </template>
 
-          <div
-            v-overlay-scrollbars="verticalOverlayScrollbars"
-            class="stress-workload"
-            data-stress-workload
-            :style="sharedWidthStyle"
-          >
-            <div class="stress-list">
-              <article
-                v-for="item in stressItems"
-                :key="`${selectedSurface}-${item.id}`"
-                class="stress-item"
-                :data-stress-item="item.limitKind"
-                :data-stress-surface-item="selectedSurface"
-              >
-                <span class="stress-item-meta">
-                  {{ selectedSurfaceLabel }} · {{ item.limitKind }}
-                </span>
-
-                <template v-if="selectedSurface === 'line'">
-                  <LineClamp
-                    v-if="item.limitKind === 'lines'"
-                    class="stress-clamp"
-                    :text="item.text"
-                    :max-lines="maxLines"
+                  <InlineClamp
+                    v-else-if="selectedSurface === 'inline'"
+                    class="stress-clamp stress-inline"
+                    :text="item.inlineText"
+                    location="middle"
                   />
-                  <LineClamp
-                    v-else
-                    class="stress-clamp"
-                    :text="item.text"
-                    :max-height="maxHeight"
-                  />
-                </template>
 
-                <template v-else-if="selectedSurface === 'rich'">
-                  <RichLineClamp
-                    v-if="item.limitKind === 'lines'"
-                    class="stress-clamp stress-rich"
-                    :html="item.html"
-                    :max-lines="maxLines"
-                  />
-                  <RichLineClamp
-                    v-else
-                    class="stress-clamp stress-rich"
-                    :html="item.html"
-                    :max-height="maxHeight"
-                  />
-                </template>
-
-                <InlineClamp
-                  v-else-if="selectedSurface === 'inline'"
-                  class="stress-clamp stress-inline"
-                  :text="item.inlineText"
-                  location="middle"
-                />
-
-                <template v-else>
-                  <WrapClamp
-                    v-if="item.limitKind === 'lines'"
-                    class="stress-clamp stress-wrap"
-                    :items="item.wrapItems"
-                    item-key="id"
-                    :max-lines="maxLines"
-                  >
-                    <template #item="{ item: wrapItem }">
-                      <span class="stress-token">{{ wrapItem.label }}</span>
-                    </template>
-                    <template #after="{ hiddenItems }">
-                      <span class="stress-token stress-token-summary">
-                        +{{ hiddenItems.length }}
-                      </span>
-                    </template>
-                  </WrapClamp>
-                  <WrapClamp
-                    v-else
-                    class="stress-clamp stress-wrap"
-                    :items="item.wrapItems"
-                    item-key="id"
-                    :max-height="maxHeight"
-                  >
-                    <template #item="{ item: wrapItem }">
-                      <span class="stress-token">{{ wrapItem.label }}</span>
-                    </template>
-                    <template #after="{ hiddenItems }">
-                      <span class="stress-token stress-token-summary">
-                        +{{ hiddenItems.length }}
-                      </span>
-                    </template>
-                  </WrapClamp>
-                </template>
-              </article>
+                  <template v-else>
+                    <WrapClamp
+                      v-if="item.limitKind === 'lines'"
+                      class="stress-clamp stress-wrap"
+                      :items="item.wrapItems"
+                      item-key="id"
+                      :max-lines="maxLines"
+                    >
+                      <template #item="{ item: wrapItem }">
+                        <span class="stress-token">{{ wrapItem.label }}</span>
+                      </template>
+                      <template #after="{ hiddenItems }">
+                        <span
+                          v-if="showAfterSlot"
+                          class="stress-token stress-token-summary"
+                          data-stress-after-slot
+                        >
+                          +{{ hiddenItems.length }}
+                        </span>
+                      </template>
+                    </WrapClamp>
+                    <WrapClamp
+                      v-else
+                      class="stress-clamp stress-wrap"
+                      :items="item.wrapItems"
+                      item-key="id"
+                      :max-height="maxHeight"
+                    >
+                      <template #item="{ item: wrapItem }">
+                        <span class="stress-token">{{ wrapItem.label }}</span>
+                      </template>
+                      <template #after="{ hiddenItems }">
+                        <span
+                          v-if="showAfterSlot"
+                          class="stress-token stress-token-summary"
+                          data-stress-after-slot
+                        >
+                          +{{ hiddenItems.length }}
+                        </span>
+                      </template>
+                    </WrapClamp>
+                  </template>
+                </article>
+              </div>
             </div>
           </div>
         </div>
@@ -661,7 +720,7 @@ onBeforeUnmount(() => {
 
 .stress-modal-scroll :deep([data-overlayscrollbars-viewport]) {
   display: grid;
-  grid-template-rows: auto auto minmax(0, 1fr);
+  grid-template-rows: auto minmax(0, 1fr);
   block-size: 100%;
   overscroll-behavior: contain;
 }
@@ -757,23 +816,41 @@ onBeforeUnmount(() => {
   box-shadow: var(--focus-ring);
 }
 
+.stress-body {
+  display: grid;
+  grid-template-columns: 292px minmax(0, 1fr);
+  min-block-size: 0;
+  block-size: 100%;
+}
+
 .stress-controls {
   display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(190px, 1fr));
-  gap: 16px 28px;
-  padding: 14px 16px;
+  align-content: start;
+  overflow: auto;
+  min-block-size: 0;
+  gap: 15px;
+  padding: 14px;
   background: color-mix(in srgb, var(--c-bg-soft) 64%, transparent);
-  border-bottom: 1px solid color-mix(in srgb, var(--c-border) 82%, transparent);
+  border-right: 1px solid color-mix(in srgb, var(--c-border) 82%, transparent);
+}
+
+.stress-control-band {
+  display: grid;
+  grid-template-columns: 1fr;
+  align-items: start;
+  min-width: 0;
+  gap: 12px;
+}
+
+.stress-control-band + .stress-control-band {
+  padding-top: 15px;
+  border-top: 1px solid color-mix(in srgb, var(--c-border) 72%, transparent);
 }
 
 .stress-control {
   display: grid;
   gap: 7px;
   min-width: 0;
-}
-
-.stress-surface-control {
-  grid-column: 1 / -1;
 }
 
 .stress-control-label {
@@ -792,9 +869,38 @@ onBeforeUnmount(() => {
   gap: 7px;
 }
 
+.stress-toggle-row {
+  display: inline-flex;
+  align-items: center;
+  min-height: 28px;
+  gap: 8px;
+  color: var(--c-text-2);
+  cursor: pointer;
+}
+
+.stress-checkbox {
+  flex: 0 0 auto;
+  inline-size: 15px;
+  block-size: 15px;
+  margin: 0;
+  accent-color: var(--c-accent);
+  cursor: pointer;
+}
+
+.stress-checkbox:focus-visible {
+  outline: none;
+  box-shadow: var(--focus-ring);
+}
+
+.stress-toggle-value {
+  font-size: 0.78rem;
+  font-weight: 600;
+  line-height: 1;
+}
+
 .stress-surface-options {
-  display: flex;
-  flex-wrap: wrap;
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
   gap: 6px;
 }
 
@@ -802,6 +908,7 @@ onBeforeUnmount(() => {
   display: inline-flex;
   align-items: center;
   justify-content: center;
+  min-width: 0;
   min-height: 28px;
   padding: 0 10px;
   font-size: 0.76rem;
@@ -900,6 +1007,7 @@ onBeforeUnmount(() => {
   display: flex;
   flex-wrap: wrap;
   align-items: flex-start;
+  justify-content: flex-start;
   gap: 8px;
 }
 
@@ -942,6 +1050,22 @@ onBeforeUnmount(() => {
   width: 100%;
 }
 
+.stress-after-slot {
+  display: inline-flex;
+  align-items: center;
+  min-height: 1.35em;
+  padding: 0 0.42em;
+  margin-inline-start: 0.4em;
+  font-size: 0.72em;
+  font-weight: 700;
+  line-height: 1;
+  color: var(--c-accent-text);
+  vertical-align: baseline;
+  background: var(--c-accent-soft);
+  border: 1px solid color-mix(in srgb, var(--c-accent) 22%, transparent);
+  border-radius: 999px;
+}
+
 .stress-wrap {
   width: 100%;
 }
@@ -963,6 +1087,32 @@ onBeforeUnmount(() => {
   color: var(--c-accent-text);
   background: var(--c-accent-soft);
   border-color: color-mix(in srgb, var(--c-accent) 22%, transparent);
+}
+
+@media (max-width: 899px) {
+  .stress-body {
+    grid-template-columns: 1fr;
+    grid-template-rows: auto minmax(0, 1fr);
+  }
+
+  .stress-controls {
+    overflow: visible;
+    border-right: none;
+    border-bottom: 1px solid color-mix(in srgb, var(--c-border) 82%, transparent);
+  }
+
+  .stress-control-band {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+
+  .stress-component-control {
+    grid-column: 1 / -1;
+  }
+
+  .stress-component-control .stress-surface-options {
+    display: flex;
+    flex-wrap: wrap;
+  }
 }
 
 @media (max-width: 639px) {
@@ -997,9 +1147,18 @@ onBeforeUnmount(() => {
   }
 
   .stress-controls {
+    gap: 12px;
+    padding: 12px;
+  }
+
+  .stress-control-band {
     grid-template-columns: 1fr;
     gap: 10px;
-    padding: 12px;
+  }
+
+  .stress-component-control .stress-surface-options {
+    display: grid;
+    grid-template-columns: repeat(2, minmax(0, 1fr));
   }
 
   .stress-workload {

--- a/packages/website/src/highlight.ts
+++ b/packages/website/src/highlight.ts
@@ -1,0 +1,24 @@
+import { createHighlighterCoreSync } from "shiki/core";
+import { createJavaScriptRegexEngine } from "shiki/engine/javascript";
+import css from "shiki/langs/css.mjs";
+import html from "shiki/langs/html.mjs";
+import js from "shiki/langs/javascript.mjs";
+import shellscript from "shiki/langs/shellscript.mjs";
+import ts from "shiki/langs/typescript.mjs";
+import vue from "shiki/langs/vue.mjs";
+import { websiteShikiTheme } from "./shiki-theme";
+
+export type HighlightLanguage = "shellscript" | "vue";
+
+const shiki = createHighlighterCoreSync({
+  engine: createJavaScriptRegexEngine(),
+  langs: [vue, shellscript, css, html, js, ts],
+  themes: [websiteShikiTheme],
+});
+
+export function highlightCode(code: string, lang: HighlightLanguage): string {
+  return shiki.codeToHtml(code, {
+    lang,
+    theme: websiteShikiTheme.name,
+  });
+}

--- a/packages/website/src/modal.ts
+++ b/packages/website/src/modal.ts
@@ -1,0 +1,197 @@
+type DialogFocusOptions = {
+  getDialog: () => HTMLElement | null;
+  getInitialFocus?: () => HTMLElement | null;
+  getRestoreFocus?: () => HTMLElement | null;
+  onEscape?: () => void;
+};
+
+type ScrollLockSnapshot = {
+  bodyLeft: string;
+  bodyOverflow: string;
+  bodyPosition: string;
+  bodyRight: string;
+  bodyTop: string;
+  bodyWidth: string;
+  htmlOverflow: string;
+  scrollX: number;
+  scrollY: number;
+};
+
+const focusableSelector = [
+  "a[href]",
+  "area[href]",
+  "button:not([disabled])",
+  "input:not([disabled]):not([type='hidden'])",
+  "select:not([disabled])",
+  "textarea:not([disabled])",
+  "iframe",
+  "object",
+  "embed",
+  "audio[controls]",
+  "video[controls]",
+  "summary",
+  '[contenteditable]:not([contenteditable="false"])',
+  '[tabindex]:not([tabindex="-1"])',
+].join(",");
+
+let scrollLockSnapshot: ScrollLockSnapshot | null = null;
+let scrollLockCount = 0;
+
+function once(cleanup: () => void): () => void {
+  let released = false;
+
+  return function releaseOnce(): void {
+    if (released) {
+      return;
+    }
+
+    released = true;
+    cleanup();
+  };
+}
+
+function focusElement(element: HTMLElement | null | undefined): void {
+  if (element?.isConnected) {
+    element.focus({ preventScroll: true });
+  }
+}
+
+function isVisibleFocusable(element: HTMLElement): boolean {
+  return (
+    element === document.activeElement ||
+    (element.getClientRects().length > 0 && getComputedStyle(element).visibility !== "hidden")
+  );
+}
+
+function focusableElementsIn(dialog: HTMLElement | null): HTMLElement[] {
+  if (!dialog) {
+    return [];
+  }
+
+  return Array.from(dialog.querySelectorAll<HTMLElement>(focusableSelector)).filter(
+    isVisibleFocusable,
+  );
+}
+
+export function trapDialogFocus({
+  getDialog,
+  getInitialFocus,
+  getRestoreFocus,
+  onEscape,
+}: DialogFocusOptions): () => void {
+  const fallbackRestoreTarget =
+    document.activeElement instanceof HTMLElement ? document.activeElement : null;
+
+  function handleKeydown(event: KeyboardEvent): void {
+    if (event.key === "Escape") {
+      event.preventDefault();
+      onEscape?.();
+      return;
+    }
+
+    if (event.key !== "Tab") {
+      return;
+    }
+
+    const dialogElement = getDialog();
+    if (!dialogElement) {
+      return;
+    }
+
+    const focusableElements = focusableElementsIn(dialogElement);
+    const firstElement = focusableElements[0] ?? getInitialFocus?.();
+    const lastElement = focusableElements.at(-1) ?? firstElement;
+    const activeElement = document.activeElement;
+
+    if (!firstElement || !lastElement) {
+      event.preventDefault();
+      return;
+    }
+
+    if (!dialogElement.contains(activeElement)) {
+      event.preventDefault();
+      focusElement(firstElement);
+      return;
+    }
+
+    if (event.shiftKey && activeElement === firstElement) {
+      event.preventDefault();
+      focusElement(lastElement);
+      return;
+    }
+
+    if (!event.shiftKey && activeElement === lastElement) {
+      event.preventDefault();
+      focusElement(firstElement);
+    }
+  }
+
+  window.addEventListener("keydown", handleKeydown);
+  focusElement(getInitialFocus?.() ?? focusableElementsIn(getDialog())[0]);
+
+  return once(() => {
+    window.removeEventListener("keydown", handleKeydown);
+    focusElement(getRestoreFocus?.() ?? fallbackRestoreTarget);
+  });
+}
+
+function captureScrollLock(): ScrollLockSnapshot {
+  const { body, documentElement } = document;
+
+  return {
+    bodyLeft: body.style.left,
+    bodyOverflow: body.style.overflow,
+    bodyPosition: body.style.position,
+    bodyRight: body.style.right,
+    bodyTop: body.style.top,
+    bodyWidth: body.style.width,
+    htmlOverflow: documentElement.style.overflow,
+    scrollX: window.scrollX,
+    scrollY: window.scrollY,
+  };
+}
+
+function applyScrollLock(snapshot: ScrollLockSnapshot): void {
+  const { body, documentElement } = document;
+
+  documentElement.style.overflow = "hidden";
+  body.style.overflow = "hidden";
+  body.style.position = "fixed";
+  body.style.top = `-${snapshot.scrollY}px`;
+  body.style.left = `-${snapshot.scrollX}px`;
+  body.style.right = "0";
+  body.style.width = "100%";
+}
+
+function restoreScrollLock(snapshot: ScrollLockSnapshot): void {
+  const { body, documentElement } = document;
+
+  documentElement.style.overflow = snapshot.htmlOverflow;
+  body.style.overflow = snapshot.bodyOverflow;
+  body.style.position = snapshot.bodyPosition;
+  body.style.top = snapshot.bodyTop;
+  body.style.left = snapshot.bodyLeft;
+  body.style.right = snapshot.bodyRight;
+  body.style.width = snapshot.bodyWidth;
+  window.scrollTo(snapshot.scrollX, snapshot.scrollY);
+}
+
+export function lockPageScroll(): () => void {
+  scrollLockCount += 1;
+
+  if (!scrollLockSnapshot) {
+    scrollLockSnapshot = captureScrollLock();
+    applyScrollLock(scrollLockSnapshot);
+  }
+
+  return once(() => {
+    scrollLockCount = Math.max(0, scrollLockCount - 1);
+
+    if (scrollLockCount > 0 || !scrollLockSnapshot) {
+      return;
+    }
+
+    restoreScrollLock(scrollLockSnapshot);
+    scrollLockSnapshot = null;
+  });
+}

--- a/packages/website/src/overlayScrollbars.ts
+++ b/packages/website/src/overlayScrollbars.ts
@@ -1,16 +1,20 @@
 import type { ObjectDirective } from "vue";
-import {
-  OverlayScrollbars,
-  type OverlayScrollbars as OverlayScrollbarsInstance,
-  type PartialOptions,
+import type {
+  OverlayScrollbars as OverlayScrollbarsInstance,
+  PartialOptions,
 } from "overlayscrollbars";
-import "overlayscrollbars/overlayscrollbars.css";
 
 const INSTANCE_KEY = Symbol("overlayScrollbars");
+const REQUEST_KEY = Symbol("overlayScrollbarsRequest");
 
 type OverlayScrollbarsTarget = HTMLElement & {
   [INSTANCE_KEY]?: OverlayScrollbarsInstance;
+  [REQUEST_KEY]?: number;
 };
+
+type OverlayScrollbarsFactory = typeof import("overlayscrollbars").OverlayScrollbars;
+
+let overlayScrollbarsLoader: Promise<OverlayScrollbarsFactory> | null = null;
 
 const defaultScrollbarOptions = {
   autoHide: "leave",
@@ -25,7 +29,7 @@ export const horizontalOverlayScrollbarsOptions = {
   },
 } satisfies PartialOptions;
 
-const bodyOverlayScrollbarsOptions = {
+export const verticalOverlayScrollbarsOptions = {
   overflow: {
     x: "hidden",
     y: "scroll",
@@ -46,10 +50,19 @@ function setInitializeAttribute(element: HTMLElement): void {
   element.setAttribute("data-overlayscrollbars-initialize", "");
 }
 
-export function initOverlayScrollbars(
+function loadOverlayScrollbars(): Promise<OverlayScrollbarsFactory> {
+  overlayScrollbarsLoader ??= Promise.all([
+    import("overlayscrollbars/overlayscrollbars.css"),
+    import("overlayscrollbars"),
+  ]).then(([, module]) => module.OverlayScrollbars);
+
+  return overlayScrollbarsLoader;
+}
+
+export async function initOverlayScrollbars(
   element: HTMLElement,
   options?: PartialOptions,
-): OverlayScrollbarsInstance {
+): Promise<OverlayScrollbarsInstance | null> {
   const target = element as OverlayScrollbarsTarget;
   const nextOptions = withDefaultOptions(options);
 
@@ -61,13 +74,22 @@ export function initOverlayScrollbars(
     return current;
   }
 
-  const instance = OverlayScrollbars(target, nextOptions);
+  const requestId = (target[REQUEST_KEY] ?? 0) + 1;
+  target[REQUEST_KEY] = requestId;
+
+  const createOverlayScrollbars = await loadOverlayScrollbars();
+  if (!target.isConnected || target[REQUEST_KEY] !== requestId) {
+    return null;
+  }
+
+  const instance = createOverlayScrollbars(target, nextOptions);
   target[INSTANCE_KEY] = instance;
   return instance;
 }
 
 export function destroyOverlayScrollbars(element: HTMLElement): void {
   const target = element as OverlayScrollbarsTarget;
+  target[REQUEST_KEY] = (target[REQUEST_KEY] ?? 0) + 1;
   target[INSTANCE_KEY]?.destroy();
   delete target[INSTANCE_KEY];
 }
@@ -78,18 +100,29 @@ export function initBodyOverlayScrollbars(): () => void {
   html.setAttribute("data-overlayscrollbars-initialize", "");
   body.setAttribute("data-overlayscrollbars-initialize", "");
 
-  const instance = OverlayScrollbars(
-    {
-      cancel: {
-        body: false,
+  let destroyed = false;
+  let instance: OverlayScrollbarsInstance | null = null;
+
+  void loadOverlayScrollbars().then((createOverlayScrollbars) => {
+    if (destroyed) {
+      return;
+    }
+
+    instance = createOverlayScrollbars(
+      {
+        cancel: {
+          body: false,
+        },
+        target: body,
       },
-      target: body,
-    },
-    withDefaultOptions(bodyOverlayScrollbarsOptions),
-  );
+      withDefaultOptions(verticalOverlayScrollbarsOptions),
+    );
+  });
 
   return () => {
-    instance.destroy();
+    destroyed = true;
+    instance?.destroy();
+    instance = null;
   };
 }
 
@@ -99,12 +132,12 @@ export const overlayScrollbarsDirective: ObjectDirective<HTMLElement, PartialOpt
       setInitializeAttribute(element);
     },
     mounted(element, binding) {
-      initOverlayScrollbars(element, binding.value);
+      void initOverlayScrollbars(element, binding.value);
     },
     updated(element, binding) {
       const { oldValue, value } = binding;
       if (value !== oldValue) {
-        initOverlayScrollbars(element, value);
+        void initOverlayScrollbars(element, value);
       }
     },
     unmounted(element) {

--- a/packages/website/src/overlayScrollbars.ts
+++ b/packages/website/src/overlayScrollbars.ts
@@ -1,151 +1,71 @@
 import type { ObjectDirective } from "vue";
+import { OverlayScrollbars } from "overlayscrollbars";
 import type {
   OverlayScrollbars as OverlayScrollbarsInstance,
   PartialOptions,
 } from "overlayscrollbars";
+import "overlayscrollbars/overlayscrollbars.css";
 
-const INSTANCE_KEY = Symbol("overlayScrollbars");
-const REQUEST_KEY = Symbol("overlayScrollbarsRequest");
+const instances = new WeakMap<HTMLElement, OverlayScrollbarsInstance>();
+const initAttr = "data-overlayscrollbars-initialize";
 
-type OverlayScrollbarsTarget = HTMLElement & {
-  [INSTANCE_KEY]?: OverlayScrollbarsInstance;
-  [REQUEST_KEY]?: number;
-};
-
-type OverlayScrollbarsFactory = typeof import("overlayscrollbars").OverlayScrollbars;
-
-let overlayScrollbarsLoader: Promise<OverlayScrollbarsFactory | null> | null = null;
-
-const defaultScrollbarOptions = {
+const scrollbars = {
   autoHide: "leave",
   autoHideDelay: 240,
   theme: "os-theme-light",
 } satisfies NonNullable<PartialOptions["scrollbars"]>;
 
-export const horizontalOverlayScrollbarsOptions = {
-  overflow: {
-    x: "scroll",
-    y: "hidden",
-  },
-} satisfies PartialOptions;
+const xOptions = { overflow: { x: "scroll", y: "hidden" }, scrollbars } satisfies PartialOptions;
+const yOptions = { overflow: { x: "hidden", y: "scroll" }, scrollbars } satisfies PartialOptions;
 
-export const verticalOverlayScrollbarsOptions = {
-  overflow: {
-    x: "hidden",
-    y: "scroll",
-  },
-} satisfies PartialOptions;
-
-function withDefaultOptions(options?: PartialOptions): PartialOptions {
-  return {
-    ...options,
-    scrollbars: {
-      ...defaultScrollbarOptions,
-      ...options?.scrollbars,
-    },
-  };
+function mark(element: HTMLElement): void {
+  element.setAttribute(initAttr, "");
 }
 
-function setInitializeAttribute(element: HTMLElement): void {
-  element.setAttribute("data-overlayscrollbars-initialize", "");
-}
+function mount(element: HTMLElement, options: PartialOptions): void {
+  mark(element);
 
-function loadOverlayScrollbars(): Promise<OverlayScrollbarsFactory | null> {
-  overlayScrollbarsLoader ??= Promise.all([
-    import("overlayscrollbars/overlayscrollbars.css"),
-    import("overlayscrollbars"),
-  ])
-    .then(([, module]) => module.OverlayScrollbars)
-    .catch(() => {
-      overlayScrollbarsLoader = null;
-      return null;
-    });
-
-  return overlayScrollbarsLoader;
-}
-
-export async function initOverlayScrollbars(
-  element: HTMLElement,
-  options?: PartialOptions,
-): Promise<OverlayScrollbarsInstance | null> {
-  const target = element as OverlayScrollbarsTarget;
-  const nextOptions = withDefaultOptions(options);
-
-  setInitializeAttribute(target);
-
-  const current = target[INSTANCE_KEY];
+  const current = instances.get(element);
   if (current) {
-    current.options(nextOptions);
-    return current;
+    current.options(options);
+    return;
   }
 
-  const requestId = (target[REQUEST_KEY] ?? 0) + 1;
-  target[REQUEST_KEY] = requestId;
-
-  const createOverlayScrollbars = await loadOverlayScrollbars();
-  if (!createOverlayScrollbars || !target.isConnected || target[REQUEST_KEY] !== requestId) {
-    return null;
-  }
-
-  const instance = createOverlayScrollbars(target, nextOptions);
-  target[INSTANCE_KEY] = instance;
-  return instance;
+  instances.set(element, OverlayScrollbars(element, options));
 }
 
-export function destroyOverlayScrollbars(element: HTMLElement): void {
-  const target = element as OverlayScrollbarsTarget;
-  target[REQUEST_KEY] = (target[REQUEST_KEY] ?? 0) + 1;
-  target[INSTANCE_KEY]?.destroy();
-  delete target[INSTANCE_KEY];
+function destroy(element: HTMLElement): void {
+  instances.get(element)?.destroy();
+  instances.delete(element);
 }
 
 export function initBodyOverlayScrollbars(): () => void {
   const { body, documentElement: html } = document;
 
-  html.setAttribute("data-overlayscrollbars-initialize", "");
-  body.setAttribute("data-overlayscrollbars-initialize", "");
+  mark(html);
+  mark(body);
 
-  let destroyed = false;
-  let instance: OverlayScrollbarsInstance | null = null;
-
-  void loadOverlayScrollbars().then((createOverlayScrollbars) => {
-    if (destroyed || !createOverlayScrollbars) {
-      return;
-    }
-
-    instance = createOverlayScrollbars(
-      {
-        cancel: {
-          body: false,
-        },
-        target: body,
+  const instance = OverlayScrollbars(
+    {
+      cancel: {
+        body: false,
       },
-      withDefaultOptions(verticalOverlayScrollbarsOptions),
-    );
-  });
+      target: body,
+    },
+    yOptions,
+  );
 
   return () => {
-    destroyed = true;
-    instance?.destroy();
-    instance = null;
+    instance.destroy();
   };
 }
 
-export const overlayScrollbarsDirective: ObjectDirective<HTMLElement, PartialOptions | undefined> =
-  {
-    beforeMount(element) {
-      setInitializeAttribute(element);
-    },
-    mounted(element, binding) {
-      void initOverlayScrollbars(element, binding.value);
-    },
-    updated(element, binding) {
-      const { oldValue, value } = binding;
-      if (value !== oldValue) {
-        void initOverlayScrollbars(element, value);
-      }
-    },
-    unmounted(element) {
-      destroyOverlayScrollbars(element);
-    },
-  };
+export const overlayScrollbarsDirective: ObjectDirective<HTMLElement> = {
+  beforeMount: mark,
+  mounted(element, binding) {
+    mount(element, binding.modifiers.y ? yOptions : xOptions);
+  },
+  unmounted(element) {
+    destroy(element);
+  },
+};

--- a/packages/website/src/overlayScrollbars.ts
+++ b/packages/website/src/overlayScrollbars.ts
@@ -14,7 +14,7 @@ type OverlayScrollbarsTarget = HTMLElement & {
 
 type OverlayScrollbarsFactory = typeof import("overlayscrollbars").OverlayScrollbars;
 
-let overlayScrollbarsLoader: Promise<OverlayScrollbarsFactory> | null = null;
+let overlayScrollbarsLoader: Promise<OverlayScrollbarsFactory | null> | null = null;
 
 const defaultScrollbarOptions = {
   autoHide: "leave",
@@ -50,11 +50,16 @@ function setInitializeAttribute(element: HTMLElement): void {
   element.setAttribute("data-overlayscrollbars-initialize", "");
 }
 
-function loadOverlayScrollbars(): Promise<OverlayScrollbarsFactory> {
+function loadOverlayScrollbars(): Promise<OverlayScrollbarsFactory | null> {
   overlayScrollbarsLoader ??= Promise.all([
     import("overlayscrollbars/overlayscrollbars.css"),
     import("overlayscrollbars"),
-  ]).then(([, module]) => module.OverlayScrollbars);
+  ])
+    .then(([, module]) => module.OverlayScrollbars)
+    .catch(() => {
+      overlayScrollbarsLoader = null;
+      return null;
+    });
 
   return overlayScrollbarsLoader;
 }
@@ -78,7 +83,7 @@ export async function initOverlayScrollbars(
   target[REQUEST_KEY] = requestId;
 
   const createOverlayScrollbars = await loadOverlayScrollbars();
-  if (!target.isConnected || target[REQUEST_KEY] !== requestId) {
+  if (!createOverlayScrollbars || !target.isConnected || target[REQUEST_KEY] !== requestId) {
     return null;
   }
 
@@ -104,7 +109,7 @@ export function initBodyOverlayScrollbars(): () => void {
   let instance: OverlayScrollbarsInstance | null = null;
 
   void loadOverlayScrollbars().then((createOverlayScrollbars) => {
-    if (destroyed) {
+    if (destroyed || !createOverlayScrollbars) {
       return;
     }
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -12,6 +12,9 @@ catalogs:
     '@types/node':
       specifier: ^25.6.0
       version: 25.6.0
+    '@types/stats.js':
+      specifier: ^0.17.4
+      version: 0.17.4
     '@vitejs/plugin-vue':
       specifier: ^6.0.6
       version: 6.0.6
@@ -33,6 +36,9 @@ catalogs:
     simple-icons:
       specifier: ^16.16.0
       version: 16.16.0
+    stats.js:
+      specifier: ^0.17.0
+      version: 0.17.0
     typescript:
       specifier: ^6.0.3
       version: 6.0.3
@@ -101,6 +107,9 @@ importers:
       simple-icons:
         specifier: 'catalog:'
         version: 16.16.0
+      stats.js:
+        specifier: 'catalog:'
+        version: 0.17.0
       vue:
         specifier: 'catalog:'
         version: 3.5.32(typescript@6.0.3)
@@ -111,6 +120,9 @@ importers:
       '@types/node':
         specifier: 'catalog:'
         version: 25.6.0
+      '@types/stats.js':
+        specifier: 'catalog:'
+        version: 0.17.4
       '@vitejs/plugin-vue':
         specifier: 'catalog:'
         version: 6.0.6(@voidzero-dev/vite-plus-core@0.1.18(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.6.1)(tsx@4.21.0)(typescript@6.0.3)(yaml@2.8.3))(vue@3.5.32(typescript@6.0.3))
@@ -724,6 +736,9 @@ packages:
   '@types/node@25.6.0':
     resolution: {integrity: sha512-+qIYRKdNYJwY3vRCZMdJbPLJAtGjQBudzZzdzwQYkEPQd+PJGixUL5QfvCLDaULoLv+RhT3LDkwEfKaAkgSmNQ==}
 
+  '@types/stats.js@0.17.4':
+    resolution: {integrity: sha512-jIBvWWShCvlBqBNIZt0KAshWpvSjhkwkEu4ZUcASoAvhmrgAUI2t1dXrjSL4xXVLB4FznPrIsX3nKXFl/Dt4vA==}
+
   '@types/unist@3.0.3':
     resolution: {integrity: sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q==}
 
@@ -1295,6 +1310,9 @@ packages:
     resolution: {integrity: sha512-H+Z29a0TrCw6mrG42V2aqHQaKdJCT87x5aojLlPiIXOf1lpMqnKFAR/jP5xkI5hLrVTCBWs33e9sOtyNWqCx1A==}
     engines: {node: '>=0.12.18'}
 
+  stats.js@0.17.0:
+    resolution: {integrity: sha512-hNKz8phvYLPEcRkeG1rsGmV5ChMjKDAWU7/OJJdDErPBNChQXxCo3WZurGpnWc6gZhAzEPFad1aVgyOANH1sMw==}
+
   sirv@3.0.2:
     resolution: {integrity: sha512-2wcC/oGxHis/BoHkkPwldgiPSYcpZK3JU28WoMVv55yHJgcZ8rlXvuG9iZggz+sU1d4bRgIGASwyWqjxu3FM0g==}
     engines: {node: '>=18'}
@@ -1834,6 +1852,8 @@ snapshots:
   '@types/node@25.6.0':
     dependencies:
       undici-types: 7.19.2
+
+  '@types/stats.js@0.17.4': {}
 
   '@types/unist@3.0.3': {}
 
@@ -2424,6 +2444,8 @@ snapshots:
       '@types/hast': 3.0.4
 
   simple-icons@16.16.0: {}
+
+  stats.js@0.17.0: {}
 
   sirv@3.0.2:
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -5,6 +5,7 @@ packages:
 catalog:
   "@lucide/vue": ^1.8.0
   "@types/node": ^25.6.0
+  "@types/stats.js": ^0.17.4
   "@vitejs/plugin-vue": ^6.0.6
   bumpp: ^11.0.1
   overlayscrollbars: ^2.15.1
@@ -12,6 +13,7 @@ catalog:
   releaselog: ^7.0.2
   shiki: ^4.0.2
   simple-icons: ^16.16.0
+  stats.js: ^0.17.0
   typescript: ^6.0.3
   vite: npm:@voidzero-dev/vite-plus-core@^0.1.18
   vite-plus: ^0.1.18


### PR DESCRIPTION
## Summary
- Improve clamp runtime paths for native text clamp and rich clamp updates.
- Add a stress playground with FPS, slot toggles, and inspector-style controls.
- Lazy-load website demo assets and record the related design notes.

## Checks
- `vp check`
- `vp test`
- `vp run test:browser`
- `vp run build`