### PR TITLE
perf: optimize WrapClamp solver

### DIFF
--- a/journey/design.md
+++ b/journey/design.md
@@ -9,6 +9,10 @@
   - `RichLineClamp` for multiline trusted-inline-html clamping
   - `InlineClamp` for measured one-line affix-friendly truncation
   - `WrapClamp` for wrapped atomic-item clamping
+- Solver design vocabulary is centralized in `journey/vocabulary.md`; WrapClamp plans and
+  implementation notes should use those terms consistently.
+- WrapClamp optimization outcomes and benchmark deltas from the May 2026 solver work are summarized
+  in `journey/research/308-wrapclamp-optimization-summary.md`.
 
 ## Product Goals
 
@@ -41,6 +45,17 @@
 - Public declaration types live in `packages/vue-clamp/src/types.ts`.
 - Component implementation files do not re-export public declaration types; type exports stay in
   `types.ts` and the root package barrel so the public surface remains auditable.
+- Type organization preference:
+  - share a type only when it has one semantic owner and multiple real consumers, or when a runtime
+    prop/helper must stay aligned with a public prop contract
+  - colocate component-local solver, DOM, probe, patch, and render-state types with the code that
+    owns those states
+  - do not create shared types only because two objects have the same shape; `RichState`,
+    `TextClampResult`, and `WrapClamp` sequence/flow states are intentionally separate concepts
+  - helper-module types may be exported for internal tests or sibling modules, but the root barrel
+    remains the only package-level public type surface
+  - `ClampLength` is the shared source-level `maxHeight` length primitive; `TextClampHint` is the
+    shared text warm-start contract
 - `LineClamp` is the text-only multiline component.
 - `RichLineClamp` is the rich-html multiline component.
 - `LineClamp` `location` accepts the keyword aliases `start`, `middle`, and `end`, plus numeric ratios from `0` to `1`.
@@ -150,11 +165,22 @@
   - no slots or exposed instance API
 - `WrapClamp` is item-driven and browser-aligned:
   - one root clamp container with live DOM measurement
-  - one inline-flex wrapping flow of atomic item shells
+  - one normal horizontal inline-flex wrapping flow of atomic item shells
   - optional `before` / `after` atomic slot shells
+  - internal measurement and flow-estimation contracts use physical `width` / `height` naming
+    because vertical writing mode is intentionally outside the supported contract
   - reactive `visibleCount`, `expanded`, and `isClamped`
   - no public strategy prop or cache-backed variant
   - no partial clipping inside an item
+  - `[data-part="content"]` is a layout-critical shell, not an arbitrary styling container:
+    - supported user-facing geometry styles are `gap`, `row-gap`, `column-gap`, and normal
+      horizontal flex-line `align-items` values such as `flex-start`, `stretch`, `center`,
+      `flex-end`, and `baseline`
+    - the solver identifies rows by vertical box overlap, so mixed-height items remain on the
+      same measured row under center/end/baseline alignment
+    - structural overrides such as `display`, `flex-wrap`, `flex-direction`, `writing-mode`,
+      padding/border/explicit content width, transforms, positioning, `order`, and
+      `content-visibility` are outside the supported contract
 
 ### Accessibility model
 
@@ -235,9 +261,156 @@
   - collapsed states are measured from the real rendered `before` / items / `after` sequence
   - the engine settles by shrinking to a fitting prefix, then probing upward one item at a time
   - measurements come from the rendered content DOM directly instead of a separate per-item ref cache
-  - large grow cases remain linear because each candidate can change arbitrary slot output and item
-    widths; cache/hint variants stay deferred until real component workloads prove a user-visible
-    win
+  - the baseline grow solver remains linear because each candidate can change arbitrary slot output
+    and item widths; narrow hints may jump to a better starting count only when benchmarked counters
+    improve and the baseline still performs final live-DOM settlement
+  - a May 2026 hidden-probe prototype for low expected work passed correctness tests but worsened
+    the table benchmark by materially increasing item slot calls and rect reads, so the hidden
+    measurement-island direction is deferred until it can prove candidate changes do not rerender
+    arbitrary item slots
+  - the accepted May 2026 fast path is deliberately narrower: no `before`, no `after`, no
+    `maxHeight`; it records item-shell widths after verified public DOM measurement and uses those
+    widths only as a visible-count hint before handing control back to the live-DOM settlement loop
+  - removing the no-affix metrics count hint was measured and rejected: the code became simpler, but
+    no-affix grow increased rect reads and median time because more work fell back to live
+    settlement
+  - later May 2026 no-affix work added two accepted solver paths:
+    - shrink-only current-prefix settlement for observed width shrink, which measures the already
+      rendered public prefix and avoids a speculative grow/revert probe
+    - bounded materialized grow search, which uses Vue once to render a hidden item-shell suffix,
+      synchronously toggles component-owned item shell display during search, mutates only the
+      changed display range between candidates, restores candidate mutation before yielding, commits
+      one final count, and verifies with live DOM
+  - materialized grow is a no-`after` static-flow path; it supports `maxLines` and no-`after`
+    `maxHeight` cases, while dynamic `after` remains excluded
+  - its materialization coverage is adaptive rather than one fixed count:
+    - estimate the likely visible frontier from the current root inline size, line limit, and
+      verified visible item widths
+    - empirical calibration across item widths and container widths showed the best fixed-width
+      frontier follows `lineLimit * floor(rootWidth / measuredItemWidth) + 1`
+    - the `+1` is intentional: it gives DOM search an overflow side when the estimate lands exactly
+      on the fitting frontier
+    - the current estimator is expressed as a small flow simulation, not only the fixed-width
+      formula: known item widths use recorded live metrics, unknown hidden item widths use the
+      observed average fallback, and the first predicted overflow item is included for DOM search
+    - cap the estimate by a per-line materialization budget so arbitrary item variation and very
+      large containers still fall back conservatively
+    - verify the final committed result against live DOM
+  - fixed materialization budgets were measured and rejected as too workload-specific:
+    - 24 was good for the original 40px-item / 520px-container benchmark and large-N case
+    - 32 was better for narrower items and wider containers
+    - the adaptive budget preserved the large-N result while matching the wider-frontier scenarios
+      more closely
+    - the later regression-calibrated frontier removed the remaining fixed-width overestimation and
+      fixed the narrow-item / wide-container under-coverage that still fell back to baseline
+  - no-affix and static-affix cases should be treated as one future `static-flow` solver family:
+    - absent `before` / `after` are zero-size static affixes
+    - static `before` / `after` can share the same item-shell materialization, DOM candidate
+      mutation, final commit, and live verification path
+    - user-facing performance hints may later enable static-after participation, but the internal
+      route should be reserved before the public API exists
+  - accepted static-flow predictions share one internal pure placement model:
+    - the model places atomic before/items/after boxes into lines by inline size
+    - unknown item widths return an `unknown` result instead of inventing proof
+    - callers decide whether an overflow result means a fitting count, a materialization frontier,
+      or a dynamic-after starting hint
+    - materialized DOM search and dynamic-after estimation share the same largest-fitting-candidate
+      binary-search helper
+  - stable `before` grow is now included in the materialized grow path when `after` is absent:
+    - stable means observed-stable inside the current solve, not inferred-static as a public
+      contract; without a user hint the component cannot know a slot is generally static
+    - the `before` shell is measured before DOM search and compared again after the final commit
+    - if the `before` geometry changes, the fast path is not accepted and the baseline solver
+      finishes settlement
+    - the frontier estimate accounts for `before` consuming first-line inline space
+  - a `staticAfter` public hint prototype was tested and rejected:
+    - even with correctness preserved by final baseline settlement, the hinted path increased item
+      slot calls, after slot calls, rect reads, and elapsed time
+    - no public hint is currently exposed; future hints need a different implementation and a
+      counter win before becoming part of the API
+  - no-`after` `maxHeight` grow now uses the same materialized item-shell DOM search:
+    - the fit predicate remains monotonic because there is no dynamic `after`
+    - candidate checks measure against the real root clip box
+    - maxHeight-only materialization budget estimates an effective line count from root visible
+      height and the first visible atomic box height
+    - the line-count estimate is only a search budget; final acceptance still comes from live DOM
+      verification
+  - shrink-only current-prefix settlement is also allowed for `before`-only / no-`after`
+    scenarios:
+    - it measures the currently rendered public sequence, commits the smaller fitting prefix once,
+      and verifies live DOM
+    - final acceptance requires the committed `before` geometry to match the geometry used for the
+      shrink decision
+    - dynamic `before` therefore falls back to baseline without leaving materialized suffix state
+  - materialized `after` grow was tested and rejected for now:
+    - final geometry comparison alone can still underfill count-sensitive `after`, because a wider
+      old `after` may prevent discovering a valid candidate with a narrower final `after`
+    - forcing `after` cases through materialized grow worsened table and single-line benchmark
+      counters, so `after` stays on the baseline path until a stricter static-affix signal exists
+    - fixed-size static-after benchmark rows now exist, but without a public/static contract they
+      intentionally use the same guarded dynamic-after path as arbitrary `after`
+  - the accepted dynamic-after optimization is a jump-grow hint, not a proof:
+    - live `measureSequence` reads now record item widths without extra item rect reads, so later
+      solves can reuse already-paid visible DOM metrics
+    - when `after` exists and `maxHeight` is absent, a large width grow may estimate a better
+      starting count by simulating `before + items + current after` with measured/average item
+      widths
+    - the hint is gated by observed geometry: the width delta must be at least one average measured
+      item width, which makes it a jump-grow path and keeps gradual width sweeps on baseline
+    - it does not create a hidden probe, does not materialize arbitrary after DOM, and does not
+      accept the estimate as final; the baseline live-DOM solver still verifies and settles
+    - the main benchmark target is stable/static before plus count-sensitive dynamic after, which
+      dropped from about `48100` item slot calls, `52100` rect reads, and `500ms` to about `17500`,
+      `14700`, and `186ms`
+    - arbitrary dynamic before remains lower priority because before geometry appears before all
+      items and can invalidate every downstream line break
+    - widening the jump-grow hint to gradual grow was measured and rejected: slot calls stayed flat
+      while rect reads rose in both table and single-line sweeps
+    - a dynamic-before confidence prototype that disabled static-flow paths after one before
+      geometry mismatch was also rejected; it increased before slot calls, item slot calls, rect
+      reads, and elapsed time versus the current failed-fast-path-plus-baseline behavior
+    - dedicated dynamic-before grow and shrink benchmark rows now guard that behavior
+  - `after` shrink was also tested with a conservative candidate-first path and rejected:
+    - it did not reduce slot calls
+    - it increased rect reads in both the dedicated after-shrink benchmark and the existing
+      dynamic-after table scenario
+    - after-specific shrink now stays on the baseline path, with a browser guard for hidden-count
+      digit-boundary changes
+  - no-`after` shrink is allowed to use `maxHeight` clipping now:
+    - the path still uses only the currently rendered public prefix
+    - it measures with the real root clip box, commits one smaller prefix, and verifies live DOM
+    - before+maxHeight and mixed maxLines+maxHeight benchmark rows confirm this same static-flow
+      path covers those cases without a separate solver branch
+  - a last-line slack / single-next-item probe was measured and rejected:
+    - the strict version still used live DOM by materializing only `current + 1` when the width
+      estimator predicted no count increase
+    - it was correct, but incomplete hidden-item width data made it under-materialize grow cases,
+      then fall back to linear baseline
+    - no-affix grow slot calls and rect reads rose sharply, so this path should not be revived
+      without a stronger verified slack model
+  - scheduler work remains deliberately scoped:
+    - a table width-churn benchmark now tracks same-batch parent width changes
+    - a microtask scheduler prototype passed correctness but did not reduce slot calls or rect
+      reads, so it was rejected
+    - a broader global scheduler should not be introduced until paired with a solver change that
+      demonstrably reduces candidate work without delaying ResizeObserver settlement past a paint
+  - CSS gap, content alignment, and reactive slot-width changes are covered by browser guards:
+    - CSS gap is left to final live DOM verification rather than approximated in the estimator
+    - content `align-items:center` and `align-items:baseline` with mixed-height items are covered
+      by block-overlap row detection instead of top-equality grouping
+    - reactive item width changes with the same `items` array settle through ResizeObserver,
+      same-flush updates, and live DOM verification; no item-array identity cache is trusted
+  - vertical/sideways writing mode is deliberately outside WrapClamp's supported contract:
+    - `maxLines` and `maxHeight` are defined for horizontal wrapping rows and the root's vertical
+      clip box
+    - the solver no longer inspects CSS `writing-mode` or maps DOM rects to logical axes
+    - future vertical behavior would need explicit product/API design rather than implicit solver
+      branches inside the current API
+  - heavy item slot benchmark coverage confirms elapsed time follows item slot work:
+    - the heavy no-affix grow row keeps the same item slot and rect-read counts as the normal
+      no-affix grow row but takes roughly `75ms` longer
+    - this reinforces the rule that future solver branches must lower arbitrary item slot calls or
+      rect reads, not merely move the work into another rendering path
   - `hiddenItems` remains the public slot prop and is sliced directly from the current item array
   - keep item order logical in the DOM so RTL works through inherited browser direction
 

--- a/journey/design.md
+++ b/journey/design.md
@@ -42,20 +42,56 @@
   - `InlineClamp` as the canonical single-line affix-friendly component name
   - `WrapClamp` as the canonical wrapped-item component name
 - There is no default export.
-- Public declaration types live in `packages/vue-clamp/src/types.ts`.
-- Component implementation files do not re-export public declaration types; type exports stay in
-  `types.ts` and the root package barrel so the public surface remains auditable.
-- Type organization preference:
-  - share a type only when it has one semantic owner and multiple real consumers, or when a runtime
-    prop/helper must stay aligned with a public prop contract
-  - colocate component-local solver, DOM, probe, patch, and render-state types with the code that
-    owns those states
-  - do not create shared types only because two objects have the same shape; `RichState`,
-    `TextClampResult`, and `WrapClamp` sequence/flow states are intentionally separate concepts
-  - helper-module types may be exported for internal tests or sibling modules, but the root barrel
-    remains the only package-level public type surface
-  - `ClampLength` is the shared source-level `maxHeight` length primitive; `TextClampHint` is the
-    shared text warm-start contract
+- Type declarations follow four explicit layers:
+  - package API types live in `packages/vue-clamp/src/types.ts` and are re-exported from the root
+    package barrel; these names are semver API
+  - private building-block aliases may live inside `types.ts` only to assemble concrete package API
+    contracts without becoming package-level names themselves
+  - source-module helper contracts live in the behavior module that owns them, such as `text.ts`,
+    `rich.ts`, `native.ts`, and `multiline.ts`; sibling modules, tests, and benchmarks may import
+    those contracts directly from the owner module
+  - implementation-local solver, DOM, probe, patch, render-state, benchmark-fixture, and website UI
+    types stay with the code that owns those states
+- Component implementation files do not re-export package declaration types; public package type
+  exports stay auditable through `types.ts` and the root barrel.
+- Root package type exports currently include the component prop, slot, exposed-instance, and
+  user-callback/value-domain contracts:
+  - `ClampBoundary`
+  - `ClampLength`
+  - `LineClampLocation`
+  - `LineClampProps`
+  - `LineClampSlotProps`
+  - `LineClampExposed`
+  - `RichLineClampProps`
+  - `RichLineClampSlotProps`
+  - `RichLineClampExposed`
+  - `InlineClampParts`
+  - `InlineClampSplit`
+  - `InlineClampProps`
+  - `WrapClampItemKey`
+  - `WrapClampItemSlotProps`
+  - `WrapClampSlotProps`
+  - `WrapClampExposed`
+  - `WrapClampProps`
+- `LineClamp`, `RichLineClamp`, and `WrapClamp` declare their slot maps with Vue `SlotsType`.
+  These slot maps are declaration-building contracts in `types.ts`, not root package exports.
+- `WrapClamp` remains a non-specialized component whose generated slot declaration is tied to
+  `unknown` items. Precise generic item-slot support for consuming apps is deferred to a separate
+  public API design.
+- `ClampControls`, `ClampState`, `ClampSlotProps`, and `ClampExposed` are private building blocks in
+  `types.ts`; they keep concrete public contracts aligned without creating a generic cross-component
+  public abstraction.
+- `TextClampSpacing`, `PreparedText`, `TextClampHint`, `TextClampResult`, `TextClampFitInput`, and
+  `TextClampLayoutInput` are text-helper contracts owned by `text.ts`; they are intentionally not
+  root package exports.
+- `RichBoundaryPoint`, `PreparedRichTextNode`, `PreparedRichElementNode`, `PreparedRichNode`,
+  `PreparedRich`, `RichState`, `RichClampProbe`, `RichClampOptions`, and `RichClampResult` are
+  rich-helper contracts owned by `rich.ts`; they are intentionally not root package exports.
+- Helper snapshot types should be readonly where callers are not meant to mutate prepared state,
+  warm-start hints, or clamp results.
+- Do not create shared types only because two objects have the same shape; `RichState`,
+  `TextClampResult`, native mode state, and `WrapClamp` sequence/flow states are intentionally
+  separate concepts.
 - `LineClamp` is the text-only multiline component.
 - `RichLineClamp` is the rich-html multiline component.
 - `LineClamp` `location` accepts the keyword aliases `start`, `middle`, and `end`, plus numeric ratios from `0` to `1`.

--- a/journey/design.md
+++ b/journey/design.md
@@ -73,11 +73,11 @@
   - `WrapClampSlotProps`
   - `WrapClampExposed`
   - `WrapClampProps`
-- `LineClamp`, `RichLineClamp`, and `WrapClamp` declare their slot maps with Vue `SlotsType`.
-  These slot maps are declaration-building contracts in `types.ts`, not root package exports.
-- `WrapClamp` remains a non-specialized component whose generated slot declaration is tied to
-  `unknown` items. Precise generic item-slot support for consuming apps is deferred to a separate
-  public API design.
+- `LineClamp` and `RichLineClamp` declare their slot maps with Vue `SlotsType`. These slot maps are
+  declaration-building contracts in `types.ts`, not root package exports.
+- `WrapClamp` remains a non-specialized component without a declared slot map for now. Adding
+  `SlotsType<WrapClampSlots<unknown>>` makes consuming-app item slots `unknown` under `vue-tsc`;
+  precise generic item-slot support is deferred to a separate public API design.
 - `ClampControls`, `ClampState`, `ClampSlotProps`, and `ClampExposed` are private building blocks in
   `types.ts`; they keep concrete public contracts aligned without creating a generic cross-component
   public abstraction.

--- a/journey/logs/290-type-organization-review.md
+++ b/journey/logs/290-type-organization-review.md
@@ -1,0 +1,23 @@
+# Type organization review
+
+- Reframed the review from a `ClampLength`-specific export question into a full source type
+  organization pass.
+- Inventoried package API types, private `types.ts` building blocks, helper-module contracts,
+  runtime helper local types, component-local solver/probe types, and test/website consumer types.
+- Main gap: the project has an implicit layering model, but `types.ts` and the design notes do not
+  distinguish package API types from source-helper contracts clearly enough.
+- Implemented the four-layer split in source:
+  - root package API now exports `ClampLength` alongside the public component contracts
+  - text helper contracts are readonly and fully named from `text.ts`
+  - rich helper contracts are structurally complete and fully named from `rich.ts`
+  - native and multiline helper function signatures expose source-module contract types from their
+    owner modules
+  - `packages/vue-clamp/tests/type-surface.ts` type-checks package API and helper API boundaries
+- Added internal slot-map contracts (`LineClampSlots`, `RichLineClampSlots`, `WrapClampSlots<T>`)
+  and wired component implementations to Vue `SlotsType` without re-exporting those maps from the
+  package root.
+- Tried typing the raw `WrapClamp` export itself as a generic constructor, but it polluted
+  `h(WrapClamp, ...)` overload selection in current TypeScript/Vue types.
+- A `createWrapClamp<T>()` specializer was also prototyped and then removed because it would add a
+  new public API during a type-organization cleanup. Precise generic `WrapClamp` slot support is
+  deferred to a separate design.

--- a/journey/logs/290-type-organization-review.md
+++ b/journey/logs/290-type-organization-review.md
@@ -13,11 +13,13 @@
   - native and multiline helper function signatures expose source-module contract types from their
     owner modules
   - `packages/vue-clamp/tests/type-surface.ts` type-checks package API and helper API boundaries
-- Added internal slot-map contracts (`LineClampSlots`, `RichLineClampSlots`, `WrapClampSlots<T>`)
-  and wired component implementations to Vue `SlotsType` without re-exporting those maps from the
-  package root.
+- Added internal slot-map contracts (`LineClampSlots`, `RichLineClampSlots`) and wired those
+  component implementations to Vue `SlotsType` without re-exporting those maps from the package
+  root.
 - Tried typing the raw `WrapClamp` export itself as a generic constructor, but it polluted
   `h(WrapClamp, ...)` overload selection in current TypeScript/Vue types.
 - A `createWrapClamp<T>()` specializer was also prototyped and then removed because it would add a
   new public API during a type-organization cleanup. Precise generic `WrapClamp` slot support is
   deferred to a separate design.
+- `WrapClamp` slot-map wiring was also removed because `SlotsType<WrapClampSlots<unknown>>` made
+  current website SFC item slots `unknown` under `vue-tsc`.

--- a/journey/plans/290-type-organization-review.md
+++ b/journey/plans/290-type-organization-review.md
@@ -1,0 +1,254 @@
+# Type organization review
+
+## Goal
+
+Re-evaluate every TypeScript declaration layer in the Vue Clamp source tree instead of defending the
+current layout. The review covers package-facing types, source-module helper contracts,
+implementation-local types, and test/website consumer types.
+
+## Recommended type layers
+
+Use four explicit layers:
+
+1. Package API types
+   - Types consumers can import from `vue-clamp`.
+   - Source owner: `packages/vue-clamp/src/types.ts`.
+   - Export path: `packages/vue-clamp/src/index.ts`.
+   - These names are semver API.
+
+2. Component contract building blocks
+   - Private aliases inside `types.ts` that keep package API types consistent.
+   - Examples: shared controls, clamped/expanded state, exposed instance shape.
+   - They should stay private unless users need a cross-component abstraction.
+
+3. Source-module helper contracts
+   - Exported from the behavior module that owns them.
+   - Used by sibling modules, tests, or benchmarks through source imports.
+   - Not exported from `index.ts` unless they become documented package API.
+
+4. Implementation-local types
+   - Solver states, DOM probe shapes, render-only options, benchmark fixtures, and website UI
+     helper types.
+   - Stay close to the code that owns the behavior.
+
+## Current inventory and assessment
+
+### Package API candidates in `types.ts`
+
+These are correctly package-facing and should remain root exports:
+
+- `ClampBoundary`
+  - Public prop value domain for `boundary`.
+  - Used by website and tests as a consumer-facing type.
+- `LineClampLocation`
+  - Public prop value domain for `location`.
+  - The runtime accepts finite numbers and normalizes to `0..1`; TypeScript cannot express that
+    numeric range without an impractical branded API.
+- `LineClampProps`, `RichLineClampProps`, `InlineClampProps`, `WrapClampProps<T>`
+  - Public wrapper/component prop contracts.
+  - Keep in `types.ts` and root-export them.
+- `LineClampSlotProps`, `RichLineClampSlotProps`, `WrapClampSlotProps<T>`
+  - Public slot contracts.
+  - Concrete per-component names are better than exporting one base type, because future slot
+    divergence remains possible.
+- `LineClampSlots`, `RichLineClampSlots`, `WrapClampSlots<T>`
+  - Declaration-building contracts for Vue `SlotsType`.
+  - Keep them out of the root package barrel for now so this cleanup does not introduce a new
+    consumer-facing slot-map API.
+- Precise `WrapClamp` generic slot support for consuming apps remains a future public API design.
+  The raw component runtime prop accepts `readonly unknown[]`, so this cleanup should not add a
+  new specializer or cast-based public component type.
+- `LineClampExposed`, `RichLineClampExposed`, `WrapClampExposed`
+  - Public template-ref instance contracts.
+  - Runtime `expose(... satisfies ...)` checks currently keep these aligned with component code.
+- `InlineClampParts`, `InlineClampSplit`
+  - Public callback contract for the `split` prop.
+  - Root export is appropriate because users write this function directly.
+- `WrapClampItemKey<T>`, `WrapClampItemSlotProps<T>`
+  - Public item identity and item-slot contracts.
+  - `WrapClampItemKey<T>` intentionally remains permissive for template string keys and primitive
+    arrays; over-typing string keys would make Vue-template usage worse.
+
+Promoted package API value-domain type:
+
+- `ClampLength`
+  - The alias describes the public `maxHeight` value domain and is used in public prop interfaces.
+  - It is now root-exported so public declarations do not expose an unimportable named alias.
+
+Private building blocks in `types.ts`:
+
+- `ClampControls`, `ClampState`, `ClampSlotProps`, `ClampExposed`
+  - These should stay private for now.
+  - They remove duplication between public concrete types without forcing a generic cross-component
+    abstraction into the package API.
+
+Gap in `types.ts`:
+
+- The file currently acts like a package API registry but also holds at least one source-level
+  primitive (`ClampLength`). That is the real design problem; it is not limited to whether one alias
+  should be exported.
+- The file comment should distinguish package API declarations from private building blocks.
+- Slot prop aliases exist, but component implementations do not declare slot maps with Vue
+  `SlotsType`, so generated declarations do not describe slot shapes clearly.
+- There is no current public API for tying `WrapClamp` slot item types to a concrete `items`
+  element type; keep that as a separate design problem.
+
+### Helper contracts in `text.ts`
+
+Current exported helper types:
+
+- `PreparedText`
+- `TextClampHint`
+- `TextClampResult`
+
+Assessment:
+
+- These belong to `text.ts`, not `types.ts`, because the text module owns boundary preparation,
+  warm-start hints, and clamp output.
+- They should remain source-module helper contracts, not root package exports.
+- `TextClampHint` is a good shared helper contract: both `LineClamp` and `InlineClamp` use the same
+  warm-start shape.
+
+Gaps:
+
+- `PreparedText.boundaryOffsets` and `fallbackBoundaryOffsets` are typed as mutable arrays even
+  though callers should treat prepared boundary metadata as immutable.
+- `TextClampHint` and `TextClampResult` can also be made readonly to reflect their role as search
+  snapshots.
+
+Implemented adjustment:
+
+- Change exported text helper contracts to readonly field shapes:
+  - `readonly text`
+  - `readonly boundary`
+  - `readonly boundaryOffsets: readonly number[]`
+  - `readonly fallbackBoundaryOffsets?: readonly number[]`
+  - readonly `kept` and result `text`
+
+### Helper contracts in `rich.ts`
+
+Current exported helper types:
+
+- `PreparedRich`
+- `RichState`
+
+Assessment:
+
+- These belong to `rich.ts`, not `types.ts`, because rich parsing, patching, and structural state are
+  owned by the rich helper.
+- They should not be root exports.
+- `RichLineClamp` needs to store and pass these values; benchmarks also use them to compare direct
+  helper performance.
+
+Gaps:
+
+- `PreparedRich` exposes `nodes: readonly PreparedRichNode[]`, but `PreparedRichNode` is private.
+  This works as an opaque-ish helper result from `prepareRich`, but it is not a clean exported
+  structural contract.
+- `RichState` exposes `point: BoundaryPoint`, while `BoundaryPoint` is private. That makes the
+  exported type partially unnamed.
+- Rich helper states are conceptually snapshots and should be readonly.
+
+Implemented adjustment:
+
+- Export helper-level structural names from `rich.ts` so the helper contract is structurally
+  complete while still staying out of the package root.
+- Mark rich state/prepared fields readonly where practical.
+
+### Runtime prop helpers in `props.ts`
+
+Current state:
+
+- `boundaryProp`, `locationProp`, and `maxHeightProp` import public value-domain types.
+- This is correct because runtime validators and public prop declarations should agree.
+
+Gap:
+
+- If a prop value type is used by runtime prop helpers and public prop interfaces, decide whether it
+  is package API or internal helper vocabulary. Do not leave the source owner ambiguous.
+
+### Shared runtime helpers
+
+Modules:
+
+- `layout.ts`
+- `native.ts`
+- `search.ts`
+- `multiline.ts`
+- `slot.ts`
+
+Assessment:
+
+- Their local types are mostly correctly local:
+  - `LineBox`
+  - `NativeClampMode`, `NativeModeInput`
+  - `FrameRefs`, `ShellState`, `ShellOptions`
+  - inline search callback shapes
+- Exported functions can keep private parameter/return helper types when all callers use inference
+  and the module is internal-only.
+
+Gap:
+
+- If an exported helper function's return type must be stored or named by a sibling module, promote
+  that type to a source-module helper contract. Otherwise keep it local.
+
+### Component-local types
+
+Modules:
+
+- `LineClamp.ts`
+- `RichLineClamp.ts`
+- `InlineClamp.ts`
+- `WrapClamp.ts`
+
+Assessment:
+
+- Component-local DOM/probe/render-state types should stay local:
+  - `ProbeElements`
+  - `ItemKeyResolver`
+  - `SequenceMeasurement`
+  - `SequenceMeasurementOptions`
+  - `ClampLimits`
+  - `Size`
+  - `StaticFlowStatus`
+  - `StaticFlowEstimate`
+  - `StaticFlowEstimateOptions`
+- `WrapClamp` solver vocabulary is correctly kept out of `types.ts` because it is not user API.
+
+Gap:
+
+- `ItemKeyResolver` overlaps with the function branch of `WrapClampItemKey<unknown>`. Keeping it
+  local is acceptable because runtime resolution intentionally erases item type to `unknown`, but a
+  short comment could make that distinction clearer.
+
+### Test and website types
+
+Assessment:
+
+- Browser tests that model consumer usage should import package API types from `src/index.ts`.
+- Benchmarks may import helper-module contracts from `text.ts` and `rich.ts`.
+- Website code should import only root package types from `vue-clamp`; it currently does.
+
+Gap:
+
+- There is no dedicated type-surface smoke file. `exports.test.ts` checks runtime exports only, so
+  type-only drift is caught only incidentally by tests/website imports.
+
+Implemented adjustment:
+
+- Add a lightweight type-only smoke test checked by `vp check` that imports the intended public type
+  names from `src/index.ts` and intentionally does not import helper-module contracts.
+- Add internal slot-map types and wire component implementations to Vue `SlotsType`.
+
+## Recommended cleanup sequence
+
+1. Rewrite the type organization note in `journey/design.md` so it describes the four layers above.
+2. Promote `ClampLength` to the root package API because public props use the named alias.
+3. Make text helper contracts readonly.
+4. Make rich helper contracts structurally complete within `rich.ts`, then mark snapshot fields
+   readonly.
+5. Add a type-surface smoke file so `vp check` protects root type exports intentionally.
+6. Add internal slot-map contracts for Vue `SlotsType`.
+7. Keep precise `WrapClamp` generic slot support out of this cleanup and handle it in a separate
+   public API design.
+8. Keep solver/probe/state types local unless a real sibling module needs to name them.

--- a/journey/plans/290-type-organization-review.md
+++ b/journey/plans/290-type-organization-review.md
@@ -51,13 +51,13 @@ These are correctly package-facing and should remain root exports:
   - Public slot contracts.
   - Concrete per-component names are better than exporting one base type, because future slot
     divergence remains possible.
-- `LineClampSlots`, `RichLineClampSlots`, `WrapClampSlots<T>`
+- `LineClampSlots`, `RichLineClampSlots`
   - Declaration-building contracts for Vue `SlotsType`.
   - Keep them out of the root package barrel for now so this cleanup does not introduce a new
     consumer-facing slot-map API.
 - Precise `WrapClamp` generic slot support for consuming apps remains a future public API design.
   The raw component runtime prop accepts `readonly unknown[]`, so this cleanup should not add a
-  new specializer or cast-based public component type.
+  new specializer, cast-based public component type, or `SlotsType<...unknown>` slot map.
 - `LineClampExposed`, `RichLineClampExposed`, `WrapClampExposed`
   - Public template-ref instance contracts.
   - Runtime `expose(... satisfies ...)` checks currently keep these aligned with component code.
@@ -88,8 +88,9 @@ Gap in `types.ts`:
   primitive (`ClampLength`). That is the real design problem; it is not limited to whether one alias
   should be exported.
 - The file comment should distinguish package API declarations from private building blocks.
-- Slot prop aliases exist, but component implementations do not declare slot maps with Vue
-  `SlotsType`, so generated declarations do not describe slot shapes clearly.
+- Slot prop aliases exist, but `LineClamp` and `RichLineClamp` component implementations do not
+  declare slot maps with Vue `SlotsType`, so generated declarations do not describe slot shapes
+  clearly.
 - There is no current public API for tying `WrapClamp` slot item types to a concrete `items`
   element type; keep that as a separate design problem.
 
@@ -238,7 +239,8 @@ Implemented adjustment:
 
 - Add a lightweight type-only smoke test checked by `vp check` that imports the intended public type
   names from `src/index.ts` and intentionally does not import helper-module contracts.
-- Add internal slot-map types and wire component implementations to Vue `SlotsType`.
+- Add internal slot-map types for `LineClamp` and `RichLineClamp`, then wire those implementations
+  to Vue `SlotsType`.
 
 ## Recommended cleanup sequence
 
@@ -248,7 +250,7 @@ Implemented adjustment:
 4. Make rich helper contracts structurally complete within `rich.ts`, then mark snapshot fields
    readonly.
 5. Add a type-surface smoke file so `vp check` protects root type exports intentionally.
-6. Add internal slot-map contracts for Vue `SlotsType`.
+6. Add internal `LineClamp` and `RichLineClamp` slot-map contracts for Vue `SlotsType`.
 7. Keep precise `WrapClamp` generic slot support out of this cleanup and handle it in a separate
    public API design.
 8. Keep solver/probe/state types local unless a real sibling module needs to name them.

--- a/journey/research/308-wrapclamp-optimization-summary.md
+++ b/journey/research/308-wrapclamp-optimization-summary.md
@@ -1,0 +1,152 @@
+# WrapClamp optimization branch summary
+
+## Purpose
+
+This note summarizes the practical effect of the `feat/1.5` WrapClamp optimization branch for
+reviewers. It is intentionally outcome-focused: what changed, where users should feel it, what the
+benchmark says, and which tempting paths were deliberately rejected.
+
+## One-screen summary
+
+The branch changes WrapClamp from a mostly linear "render a count, measure, grow/shrink one item"
+solver into a guarded multi-path solver:
+
+- shrink paths measure the currently rendered public prefix and jump directly to a fitting count
+  when the root gets narrower
+- no-`after` grow paths materialize a bounded hidden suffix once, binary-search component-owned item
+  shells with direct `display` toggles, then commit and verify the final public DOM
+- dynamic `after(hiddenItems)` grow gets only a starting-count hint on large width jumps; live DOM
+  settlement remains the final proof
+- maxHeight participates in the same no-`after` materialized grow and shrink paths
+- all accepted fast paths verify final live DOM before they are allowed to return
+
+The public component contract is unchanged: props, slots, emitted events, exposed methods, DOM parts,
+and item ordering stay the same.
+
+## Where the win comes from
+
+The old expensive cases repeatedly invoked user item slots and layout reads while walking the count
+frontier. The accepted paths reduce that churn in three ways:
+
+1. Use measured item-shell widths as hints instead of treating every resize as a cold solve.
+2. For static-flow cases, render a hidden suffix once and search by mutating already-rendered item
+   shells instead of rerendering each candidate through Vue.
+3. For count-sensitive `after`, jump closer to the final count only when the width change is large
+   enough to justify the hint, then let baseline live-DOM settlement finish.
+
+This means the branch helps most when a resize crosses many items, when many WrapClamp instances are
+invalidated together, or when item slots are expensive.
+
+## Headline benchmark wins
+
+Current "after" numbers below are from:
+
+```sh
+vp test -c vite.browser.benchmark.config.ts packages/vue-clamp/tests/wrap.browser.benchmark.ts
+```
+
+run locally on 2026-05-11. Before numbers are the accepted baselines recorded during the optimization
+work and preserved here as the compact audit record.
+
+| Scenario                                |          Item slot calls |               Rect reads |             Median total |
+| --------------------------------------- | -----------------------: | -----------------------: | -----------------------: |
+| Static before + dynamic after jump grow |  `48100 -> 17500` (-64%) |  `52100 -> 14700` (-72%) | `~500ms -> 196ms` (-61%) |
+| No-affix tiny-item wide grow            | `131520 -> 20480` (-84%) | `135760 -> 33280` (-75%) | `~387ms -> 158ms` (-59%) |
+| Before-affix grow                       |  `48200 -> 10300` (-79%) |  `47000 -> 26600` (-43%) | `~436ms -> 190ms` (-56%) |
+| Before-affix shrink                     |   `12500 -> 6900` (-45%) |   `12800 -> 7600` (-41%) |  `~137ms -> 76ms` (-45%) |
+| maxHeight grow                          |   `16700 -> 5800` (-65%) |  `16400 -> 13000` (-21%) | `~208ms -> 132ms` (-37%) |
+| maxHeight shrink                        |    `8000 -> 4200` (-48%) |    `7500 -> 5000` (-33%) |  `~115ms -> 65ms` (-43%) |
+| No-affix hidden grow                    |  `42300 -> 22300` (-47%) |  `39000 -> 23000` (-41%) | `~330ms -> 222ms` (-33%) |
+| No-affix large-N                        |   `13360 -> 5360` (-60%) |   `12720 -> 7120` (-44%) |   `~80ms -> 54ms` (-32%) |
+| Table width churn                       |  `15200 -> 12200` (-20%) |   `10000 -> 5800` (-42%) | `~215ms -> 165ms` (-23%) |
+
+Interpretation:
+
+- The biggest wins are not small micro-optimizations. They remove whole classes of candidate
+  rerenders and repeated measurements.
+- The elapsed-time reductions track the slot-call reductions. The heavy-item-slot benchmark keeps
+  the same counters as normal hidden grow, but median time rises from about `222ms` to `304ms`,
+  confirming that fewer user slot calls matter when real item rendering is expensive.
+- Dynamic-after gradual width sweeps intentionally do not get a speculative path; prototypes raised
+  rect reads without reducing slot calls.
+
+## Current benchmark shape
+
+Latest local benchmark medians from the current branch state:
+
+| Scenario                           |  Item | Before | After |  Rect |   Total |
+| ---------------------------------- | ----: | -----: | ----: | ----: | ------: |
+| `single-line-width-sweep`          |    68 |     52 |    52 |   140 | 129.5ms |
+| `table-demo-width-sweep`           | 15300 |      0 |  3000 | 14400 | 313.1ms |
+| `table-demo-width-churn`           | 12200 |      0 |  2600 |  5800 | 165.0ms |
+| `no-affix-jump-grow`               |  6600 |      0 |     0 |  5400 | 116.4ms |
+| `no-affix-shrink`                  |  3700 |      0 |     0 |  3800 |  82.5ms |
+| `no-affix-hidden-grow`             | 22300 |      0 |     0 | 23000 | 222.1ms |
+| `no-affix-large-n`                 |  5360 |      0 |     0 |  7120 |  54.2ms |
+| `no-affix-narrow-item-grow`        | 11280 |      0 |     0 | 14760 |  98.8ms |
+| `no-affix-wide-item-grow`          |  5160 |      0 |     0 |  6060 |  60.7ms |
+| `no-affix-wide-container-grow`     | 11640 |      0 |     0 | 15480 | 108.1ms |
+| `no-affix-tiny-item-wide-grow`     | 20480 |      0 |     0 | 33280 | 158.0ms |
+| `no-affix-mixed-item-grow`         |  7980 |      0 |     0 | 11340 |  87.0ms |
+| `no-affix-heavy-item-grow`         | 22300 |      0 |     0 | 23000 | 303.9ms |
+| `before-affix-grow`                | 10300 |    800 |     0 | 26600 | 190.3ms |
+| `before-affix-shrink`              |  6900 |    800 |     0 |  7600 |  76.0ms |
+| `dynamic-before-grow`              | 25500 |   1900 |     0 | 41100 | 298.6ms |
+| `dynamic-before-shrink`            |  9700 |   1100 |     0 | 10900 | 106.2ms |
+| `static-after-grow`                | 15500 |      0 |  1300 | 10600 | 154.3ms |
+| `static-after-shrink`              | 17900 |      0 |  2100 | 16000 | 185.4ms |
+| `static-before-dynamic-after-grow` | 17500 |   1600 |  1600 | 14700 | 196.1ms |
+| `after-affix-shrink`               | 18600 |      0 |  2300 | 17300 | 210.8ms |
+| `max-height-grow`                  |  5800 |      0 |     0 | 13000 | 132.0ms |
+| `max-height-shrink`                |  4200 |      0 |     0 |  5000 |  65.0ms |
+| `before-max-height-grow`           |  6100 |    800 |     0 | 16200 | 144.3ms |
+| `before-max-height-shrink`         |  2700 |    800 |     0 |  5000 |  63.3ms |
+| `mixed-lines-height-grow`          |  5800 |      0 |     0 | 13000 | 130.1ms |
+| `mixed-lines-height-shrink`        |  4200 |      0 |     0 |  5000 |  63.5ms |
+
+Benchmark caveats:
+
+- `Total` is browser-settled elapsed time, including Vue updates, DOM/layout work, and the benchmark
+  observation loop. It is not pure solver CPU time.
+- Slot-call and rect-read counters are the more stable regression signals.
+- Browser runs still print Chromium's non-fatal ResizeObserver loop notification.
+
+## Correctness and coverage added
+
+The branch adds browser guards for the behaviors that make these fast paths safe:
+
+- no hidden materialized probe items remain after settlement
+- materialized grow continues through baseline settlement if the search upper bound is too low
+- stable `before` grow/shrink accepts only when before geometry stays stable
+- dynamic `before` geometry falls back without underfilling or leaking hidden probes
+- count-sensitive `after` digit-boundary changes settle correctly on grow and shrink
+- `maxHeight`, `maxLines + maxHeight`, and before+maxHeight use the real root clip box
+- CSS gap and common flex `align-items` values keep line counting correct
+- reactive item width changes settle even when the `items` array identity does not change
+- mixed-width and heavy-item-slot workloads are benchmarked
+
+## Deliberately rejected paths
+
+Several plausible optimizations were prototyped and rejected because they either failed correctness
+proofs or made benchmark counters worse:
+
+- materialized arbitrary `after` grow
+- dynamic-after hint on gradual width changes
+- conservative after-shrink candidate path
+- public `staticAfter` hint prototype
+- dynamic-before confidence disabling after geometry mismatch
+- one-item last-line slack probe
+- standalone microtask scheduler change
+
+This is a useful part of the branch: the final solver is not "all possible fast paths"; it is the
+subset that had a clear correctness proof and counter win.
+
+## Reviewer-facing summary
+
+For a PR description, the shortest accurate framing is:
+
+> Optimize WrapClamp resize settlement by replacing many linear grow/shrink passes with verified
+> static-flow hints and bounded materialized DOM search. The public API and DOM parts are unchanged.
+> The largest benchmarked wins reduce item slot calls by 45-84%, layout rect reads by 21-75%, and
+> settled elapsed time by 23-61% in the affected grow/shrink scenarios, while dynamic affix cases
+> without a safe proof remain on the baseline live-DOM solver.

--- a/journey/research/308-wrapclamp-performance-chart.svg
+++ b/journey/research/308-wrapclamp-performance-chart.svg
@@ -1,0 +1,125 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="920" height="520" viewBox="0 0 920 520" role="img" aria-labelledby="title desc">
+  <title id="title">WrapClamp benchmark median settled time before and after optimization</title>
+  <desc id="desc">Horizontal bar chart comparing representative WrapClamp benchmark scenarios before and after the optimization branch. Lower median settled time is better.</desc>
+  <defs>
+    <style>
+      text {
+        font-family:
+          Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+        fill: #172033;
+      }
+      .title {
+        font-size: 26px;
+        font-weight: 760;
+      }
+      .subtitle {
+        fill: #536078;
+        font-size: 14px;
+      }
+      .axis {
+        fill: #6b7486;
+        font-size: 12px;
+      }
+      .label {
+        font-size: 13px;
+        font-weight: 650;
+      }
+      .value {
+        fill: #374151;
+        font-size: 12px;
+        font-variant-numeric: tabular-nums;
+      }
+      .legend {
+        fill: #4b5563;
+        font-size: 12px;
+        font-weight: 650;
+      }
+      .delta {
+        fill: #047857;
+        font-size: 12px;
+        font-weight: 760;
+      }
+    </style>
+  </defs>
+
+  <rect width="920" height="520" rx="18" fill="#fbfcfe" />
+  <rect x="24" y="24" width="872" height="472" rx="14" fill="#ffffff" stroke="#e5e7eb" />
+
+  <text class="title" x="48" y="68">WrapClamp optimization impact</text>
+  <text class="subtitle" x="48" y="92">Median browser-settled time in representative resize scenarios. Lower is better.</text>
+
+  <rect x="610" y="52" width="12" height="12" rx="3" fill="#cbd5e1" />
+  <text class="legend" x="630" y="62">Before</text>
+  <rect x="700" y="52" width="12" height="12" rx="3" fill="#2563eb" />
+  <text class="legend" x="720" y="62">After</text>
+
+  <g transform="translate(300 118)">
+    <line x1="0" y1="0" x2="520" y2="0" stroke="#e5e7eb" />
+    <line x1="0" y1="0" x2="0" y2="336" stroke="#d1d5db" />
+    <line x1="130" y1="0" x2="130" y2="336" stroke="#f1f5f9" />
+    <line x1="260" y1="0" x2="260" y2="336" stroke="#f1f5f9" />
+    <line x1="390" y1="0" x2="390" y2="336" stroke="#f1f5f9" />
+    <line x1="520" y1="0" x2="520" y2="336" stroke="#f1f5f9" />
+    <text class="axis" x="-4" y="-10" text-anchor="middle">0</text>
+    <text class="axis" x="130" y="-10" text-anchor="middle">125ms</text>
+    <text class="axis" x="260" y="-10" text-anchor="middle">250ms</text>
+    <text class="axis" x="390" y="-10" text-anchor="middle">375ms</text>
+    <text class="axis" x="520" y="-10" text-anchor="middle">500ms</text>
+  </g>
+
+  <g transform="translate(48 136)">
+    <text class="label" x="0" y="8">Static before + dynamic after grow</text>
+    <rect x="252" y="-2" width="520" height="14" rx="7" fill="#cbd5e1" />
+    <rect x="252" y="18" width="204" height="14" rx="7" fill="#2563eb" />
+    <text class="value" x="782" y="9">~500ms</text>
+    <text class="value" x="466" y="29">196ms</text>
+    <text class="delta" x="842" y="20">-61%</text>
+  </g>
+
+  <g transform="translate(48 196)">
+    <text class="label" x="0" y="8">No-affix tiny-item wide grow</text>
+    <rect x="252" y="-2" width="402" height="14" rx="7" fill="#cbd5e1" />
+    <rect x="252" y="18" width="164" height="14" rx="7" fill="#2563eb" />
+    <text class="value" x="664" y="9">~387ms</text>
+    <text class="value" x="426" y="29">158ms</text>
+    <text class="delta" x="842" y="20">-59%</text>
+  </g>
+
+  <g transform="translate(48 256)">
+    <text class="label" x="0" y="8">Before-affix grow</text>
+    <rect x="252" y="-2" width="453" height="14" rx="7" fill="#cbd5e1" />
+    <rect x="252" y="18" width="198" height="14" rx="7" fill="#2563eb" />
+    <text class="value" x="715" y="9">~436ms</text>
+    <text class="value" x="460" y="29">190ms</text>
+    <text class="delta" x="842" y="20">-56%</text>
+  </g>
+
+  <g transform="translate(48 316)">
+    <text class="label" x="0" y="8">Before-affix shrink</text>
+    <rect x="252" y="-2" width="142" height="14" rx="7" fill="#cbd5e1" />
+    <rect x="252" y="18" width="79" height="14" rx="7" fill="#2563eb" />
+    <text class="value" x="404" y="9">~137ms</text>
+    <text class="value" x="341" y="29">76ms</text>
+    <text class="delta" x="842" y="20">-45%</text>
+  </g>
+
+  <g transform="translate(48 376)">
+    <text class="label" x="0" y="8">maxHeight grow</text>
+    <rect x="252" y="-2" width="216" height="14" rx="7" fill="#cbd5e1" />
+    <rect x="252" y="18" width="137" height="14" rx="7" fill="#2563eb" />
+    <text class="value" x="478" y="9">~208ms</text>
+    <text class="value" x="399" y="29">132ms</text>
+    <text class="delta" x="842" y="20">-37%</text>
+  </g>
+
+  <g transform="translate(48 436)">
+    <text class="label" x="0" y="8">Table width churn</text>
+    <rect x="252" y="-2" width="224" height="14" rx="7" fill="#cbd5e1" />
+    <rect x="252" y="18" width="172" height="14" rx="7" fill="#2563eb" />
+    <text class="value" x="486" y="9">~215ms</text>
+    <text class="value" x="434" y="29">165ms</text>
+    <text class="delta" x="842" y="20">-23%</text>
+  </g>
+
+  <text class="subtitle" x="48" y="482">Data: WrapClamp browser benchmark medians from feat/1.5. The chart shows elapsed browser-settled time, not pure solver CPU.</text>
+</svg>

--- a/journey/vocabulary.md
+++ b/journey/vocabulary.md
@@ -1,0 +1,97 @@
+# Vocabulary
+
+This file defines shared terms for `WrapClamp` solver design notes, plans, benchmarks, and
+implementation comments. Use these terms consistently so discussions do not blur public rendering,
+DOM measurement, prediction, and final correctness.
+
+## Core State
+
+- `public DOM`: The component-owned DOM that represents the user-facing component instance.
+- `public render path`: Vue state and render output that produce the public DOM.
+- `public commit`: A Vue state write that changes user-facing output, such as assigning
+  `visibleCount.value`.
+- `steady state`: The component state after settlement completes. It must not contain speculative
+  candidate state.
+- `visible count`: The public semantic item boundary. `hiddenItems` is derived from this count.
+- `committed visible count`: The currently rendered public `visibleCount`.
+- `candidate`: A temporary visible-count value considered by a solver.
+- `speculative state`: Any candidate state that has not passed verification.
+- `verified count`: A candidate count accepted only after live DOM verification.
+- `clamped state`: Whether the verified visible count is less than the source item count.
+
+## Solver Flow
+
+- `settlement`: The whole process of moving from the current state to a verified count.
+- `baseline solver`: The current conservative visible-DOM solver: measure public DOM, public-commit
+  candidate changes when necessary, and settle by shrinking or growing.
+- `fast path`: A narrower solver branch that attempts to reduce work before falling back to, or
+  verifying with, the baseline solver.
+- `hint`: A prediction used to choose a better first candidate. A hint is not a correctness proof.
+- `measurement`: Any layout read used during solving.
+- `verification`: The final live DOM check before accepting a count.
+- `fallback`: Returning to the baseline solver. This is a normal correctness mechanism, not a
+  failure.
+- `mismatch`: A fast path prediction or DOM-search result that final verification rejects.
+- `confidence`: Runtime trust in a fast path or metrics source, lowered by mismatches.
+
+## DOM And Rendering
+
+- `item shell`: The component-owned wrapper around one source item, currently
+  `[data-part="item"]`.
+- `affix`: A `before` or `after` slot shell that participates in the same wrap flow as items.
+- `no-affix`: A case with neither `before` nor `after` slot.
+- `materialize`: Make item shells exist in DOM.
+- `materialized count`: Number of item shells currently present and available for measurement or
+  candidate mutation.
+- `mounted hidden suffix`: Materialized item shells beyond the public visible count, hidden from
+  layout or visibility.
+- `candidate mutation`: Synchronous direct DOM changes used to test a candidate without a Vue public
+  commit, such as toggling shell `display`.
+- `DOM search`: Candidate mutation plus layout reads over materialized DOM.
+- `measurement island`: A non-public DOM area used for measurement.
+- `hidden Vue probe`: A rejected general measurement-island strategy that duplicates arbitrary Vue
+  slot DOM and changes candidates inside that duplicate tree.
+
+## Measurement Data
+
+- `metrics`: Layout data derived from a verified or otherwise bounded DOM state.
+- `item metrics`: Per-item shell size data.
+- `line map`: Mapping from item indexes to measured visual lines.
+- `last-line slack`: Remaining inline space on the final accepted line.
+- `frontier`: The interval around the fit/overflow boundary, for example `13..21` when `13` fits
+  and `21` overflows.
+- `chunk`: A batch of newly materialized item shells.
+- `measurement budget`: Limits for a settlement pass, such as max new items, rect reads, slot calls,
+  or elapsed time.
+
+## Safety
+
+- `paint-safe`: Candidate states cannot be painted. Any candidate mutation must finish and restore
+  or commit a verified state before yielding to the browser.
+- `stale paint`: A browser paint of an old or speculative clamp state.
+- `public DOM ownership`: Vue owns the public DOM. Direct DOM mutation must be short-lived,
+  synchronous, and compatible with the next Vue patch.
+- `steady-state DOM semantics`: What DOM exists after settlement. Hidden or materialized suffixes
+  can affect selectors, refs, ids, lifecycle, images, form state, and accessibility even if they are
+  visually hidden.
+
+## Slot Categories
+
+- `stable affix`: A `before` or `after` slot whose rendered geometry does not depend on
+  `hiddenItems` or candidate count for the current fingerprint.
+- `count-sensitive after`: An `after` slot that changes with `hiddenItems`, such as `+N`.
+- `dynamic before`: A `before` slot that changes with `hiddenItems` or candidate count. It is more
+  dangerous than dynamic `after` because it appears before items in the wrap flow.
+- `arbitrary slot`: A slot whose output, geometry, side effects, or count sensitivity cannot be
+  bounded by the solver.
+
+## Important Distinctions
+
+- `materialize` is not `visible`: an item shell can exist in DOM without being part of the public
+  visible count.
+- `hint` is not `proof`: metrics can choose a candidate, but final acceptance requires
+  verification.
+- `measurement` is not `verification`: verification is the final acceptance check.
+- `public commit` is not `candidate mutation`: public commit changes Vue state; candidate mutation
+  is internal synchronous DOM work.
+- `fallback` is not failure: it is how fast paths preserve correctness.

--- a/packages/vue-clamp/src/LineClamp.ts
+++ b/packages/vue-clamp/src/LineClamp.ts
@@ -20,8 +20,8 @@ import {
 import { hasSlotContent } from "./slot.ts";
 import { clampTextToLayout, normalizeLocationRatio, prepareText } from "./text.ts";
 
-import type { CSSProperties, VNodeChild } from "vue";
-import type { LineClampExposed, LineClampSlotProps } from "./types.ts";
+import type { CSSProperties, SlotsType, VNodeChild } from "vue";
+import type { LineClampExposed, LineClampSlotProps, LineClampSlots } from "./types.ts";
 import type { TextClampResult } from "./text.ts";
 
 // Slot wrappers are inline-flex so before/after controls participate in the same
@@ -72,6 +72,7 @@ export const LineClamp = defineComponent({
   inheritAttrs: false,
   props: propsDef,
   emits: emitsDef,
+  slots: Object as SlotsType<LineClampSlots>,
   setup(props, { attrs, emit, expose, slots }) {
     const textRef = ref<HTMLElement | null>(null);
     const visibleText = ref(props.text);

--- a/packages/vue-clamp/src/RichLineClamp.ts
+++ b/packages/vue-clamp/src/RichLineClamp.ts
@@ -12,9 +12,9 @@ import {
 import { clampRich, patchRich, prepareRich } from "./rich.ts";
 import { hasSlotContent } from "./slot.ts";
 
-import type { CSSProperties } from "vue";
+import type { CSSProperties, SlotsType } from "vue";
 import type { PreparedRich, RichState } from "./rich.ts";
-import type { RichLineClampExposed, RichLineClampSlotProps } from "./types.ts";
+import type { RichLineClampExposed, RichLineClampSlotProps, RichLineClampSlots } from "./types.ts";
 
 const slotStyle: CSSProperties = {
   display: "inline-flex",
@@ -77,6 +77,7 @@ export const RichLineClamp = defineComponent({
   inheritAttrs: false,
   props: propsDef,
   emits: emitsDef,
+  slots: Object as SlotsType<RichLineClampSlots>,
   setup(props, { attrs, emit, expose, slots }) {
     const probeRef = ref<HTMLElement | null>(null);
     const isFallback = ref(false);

--- a/packages/vue-clamp/src/WrapClamp.ts
+++ b/packages/vue-clamp/src/WrapClamp.ts
@@ -20,13 +20,8 @@ import { blockAsProp, expandedProp, maxHeightProp, maxLinesProp } from "./props.
 import { findLargestFittingCount } from "./search.ts";
 import { hasSlotContent } from "./slot.ts";
 
-import type { CSSProperties, PropType, SlotsType, VNodeChild } from "vue";
-import type {
-  WrapClampExposed,
-  WrapClampItemSlotProps,
-  WrapClampSlotProps,
-  WrapClampSlots,
-} from "./types.ts";
+import type { CSSProperties, PropType, VNodeChild } from "vue";
+import type { WrapClampExposed, WrapClampItemSlotProps, WrapClampSlotProps } from "./types.ts";
 
 type ItemKeyResolver = (item: unknown, index: number) => string | number;
 type SequenceMeasurement = {
@@ -349,7 +344,6 @@ export const WrapClamp = defineComponent({
   inheritAttrs: false,
   props: propsDef,
   emits: emitsDef,
-  slots: Object as SlotsType<WrapClampSlots>,
   setup(props, { attrs, emit, expose, slots }) {
     const { expanded: expandedProp, items: initialItems } = props;
     const rootRef = ref<HTMLElement | null>(null);

--- a/packages/vue-clamp/src/WrapClamp.ts
+++ b/packages/vue-clamp/src/WrapClamp.ts
@@ -17,21 +17,50 @@ import {
   normalizeLineLimit,
 } from "./layout.ts";
 import { blockAsProp, expandedProp, maxHeightProp, maxLinesProp } from "./props.ts";
+import { findLargestFittingCount } from "./search.ts";
 import { hasSlotContent } from "./slot.ts";
 
 import type { CSSProperties, PropType, VNodeChild } from "vue";
-import type {
-  WrapClampExposed,
-  WrapClampItemKey,
-  WrapClampItemSlotProps,
-  WrapClampSlotProps,
-} from "./types.ts";
+import type { WrapClampExposed, WrapClampItemSlotProps, WrapClampSlotProps } from "./types.ts";
 
-type ItemKeyResolver = Exclude<WrapClampItemKey<unknown>, string>;
+type ItemKeyResolver = (item: unknown, index: number) => string | number;
 type SequenceMeasurement = {
   allFit: boolean;
   visibleItems: number;
 };
+type SequenceMeasurementOptions = {
+  recordItemWidth?: (index: number, width: number) => void;
+};
+type ClampLimits = {
+  clipToRootHeight: boolean;
+  lineLimit: number | undefined;
+};
+type Size = {
+  height: number;
+  width: number;
+};
+type StaticFlowStatus = "fit" | "overflow" | "unknown";
+type StaticFlowEstimate = {
+  fitCount: number;
+  status: StaticFlowStatus;
+};
+type StaticFlowEstimateOptions = {
+  afterWidth?: number;
+  beforeWidth?: number;
+  containerWidth: number;
+  itemCount: number;
+  itemWidth: (index: number) => number | null;
+  lineLimit: number;
+};
+
+// DOMRect reads can differ by sub-pixel fractions across layout passes. Half a
+// CSS pixel keeps those harmless differences from becoming clamp churn.
+const layoutTolerance = 0.5;
+// Materialized grow budgets are performance caps, not correctness caps. If the
+// search reaches a cap while items remain, the fast path rejects and baseline
+// settlement continues from the committed count.
+const fallbackMaterializedGrowItems = 32;
+const maxMaterializedGrowItemsPerLine = 48;
 
 // WrapClamp treats each rendered item and slot as an atomic inline-flex box. It
 // never clips through an item because callers own item rendering semantics.
@@ -40,6 +69,11 @@ const itemStyle: CSSProperties = {
   maxWidth: "100%",
   verticalAlign: "baseline",
   whiteSpace: "nowrap",
+};
+
+const hiddenItemStyle: CSSProperties = {
+  ...itemStyle,
+  display: "none",
 };
 
 const contentStyle: CSSProperties = {
@@ -106,12 +140,123 @@ function defaultItemText(item: unknown): string {
   return typeof serialized === "string" ? serialized : "";
 }
 
+function isPositiveFiniteSize(value: number | null | undefined): value is number {
+  return typeof value === "number" && Number.isFinite(value) && value > 0;
+}
+
+function simulateStaticFlow({
+  afterWidth = 0,
+  beforeWidth = 0,
+  containerWidth,
+  itemCount,
+  itemWidth,
+  lineLimit,
+}: StaticFlowEstimateOptions): StaticFlowEstimate {
+  let currentLineWidth = Math.max(0, beforeWidth);
+  let lineCount = 1;
+  let fitCount = 0;
+
+  for (let index = 0; index < itemCount; index += 1) {
+    const width = itemWidth(index);
+    if (!isPositiveFiniteSize(width)) {
+      return {
+        fitCount,
+        status: "unknown",
+      };
+    }
+
+    if (currentLineWidth > 0 && currentLineWidth + width > containerWidth + layoutTolerance) {
+      lineCount += 1;
+      currentLineWidth = 0;
+
+      if (lineCount > lineLimit) {
+        return {
+          fitCount,
+          status: "overflow",
+        };
+      }
+    }
+
+    currentLineWidth += width;
+    fitCount = index + 1;
+  }
+
+  if (afterWidth > 0) {
+    if (currentLineWidth > 0 && currentLineWidth + afterWidth > containerWidth + layoutTolerance) {
+      lineCount += 1;
+      currentLineWidth = 0;
+
+      if (lineCount > lineLimit) {
+        return {
+          fitCount,
+          status: "overflow",
+        };
+      }
+    }
+
+    if (currentLineWidth + afterWidth > containerWidth + layoutTolerance) {
+      return {
+        fitCount,
+        status: "overflow",
+      };
+    }
+  }
+
+  return {
+    fitCount,
+    status: "fit",
+  };
+}
+
+function measureElementSize(element: HTMLElement | null): Size | null {
+  if (!element) {
+    return null;
+  }
+
+  const { height, width } = element.getBoundingClientRect();
+  if (!isPositiveFiniteSize(width) || !isPositiveFiniteSize(height)) {
+    return null;
+  }
+
+  return {
+    height,
+    width,
+  };
+}
+
+function isSameSize(current: Size | null, next: Size | null): boolean {
+  if (current === null || next === null) {
+    return current === next;
+  }
+
+  return (
+    Math.abs(current.width - next.width) <= layoutTolerance &&
+    Math.abs(current.height - next.height) <= layoutTolerance
+  );
+}
+
+function isSameMeasuredLine(rect: DOMRectReadOnly, lineTop: number, lineBottom: number): boolean {
+  const verticalOverlap = Math.min(rect.bottom, lineBottom) - Math.max(rect.top, lineTop);
+  const smallerHeight = Math.min(rect.height, lineBottom - lineTop);
+  return verticalOverlap > Math.min(layoutTolerance, smallerHeight / 2);
+}
+
 function measureSequence(
   rootElement: HTMLElement,
   contentElement: HTMLElement | null,
-  lineLimit: number | undefined,
-  clipToRootHeight: boolean,
+  limits: ClampLimits,
+  options: SequenceMeasurementOptions = {},
 ): SequenceMeasurement {
+  const { clipToRootHeight, lineLimit } = limits;
+
+  if (!contentElement) {
+    // Missing content is a lifecycle state, not evidence that items are hidden.
+    return {
+      allFit: true,
+      visibleItems: 0,
+    };
+  }
+
   let visibleTop = 0;
   let visibleBottom = 0;
 
@@ -124,16 +269,9 @@ function measureSequence(
   }
 
   let lineCount = 0;
-  let previousTop: number | null = null;
+  let lineTop = 0;
+  let lineBottom = 0;
   let visibleItems = 0;
-
-  if (!contentElement) {
-    // Missing content is a lifecycle state, not evidence that items are hidden.
-    return {
-      allFit: true,
-      visibleItems: 0,
-    };
-  }
 
   for (const child of contentElement.children) {
     if (!(child instanceof HTMLElement)) {
@@ -146,16 +284,27 @@ function measureSequence(
       continue;
     }
 
-    const { bottom, height, top, width } = child.getBoundingClientRect();
-    if (width <= 0 || height <= 0) {
+    const rect = child.getBoundingClientRect();
+    if (!isPositiveFiniteSize(rect.width) || !isPositiveFiniteSize(rect.height)) {
       continue;
     }
 
-    if (previousTop === null || Math.abs(top - previousTop) > 0.5) {
-      // Wrapped inline-flex children share a line by vertical position. The
-      // tolerance absorbs sub-pixel rounding differences across browsers.
-      lineCount += 1;
-      previousTop = top;
+    if (lineCount === 0) {
+      lineCount = 1;
+      lineTop = rect.top;
+      lineBottom = rect.bottom;
+    } else {
+      // Mixed-height flex items can have different top coordinates under
+      // center, end, or baseline alignment. Same-line boxes still overlap in
+      // the vertical axis in the supported horizontal flex-flow model.
+      if (!isSameMeasuredLine(rect, lineTop, lineBottom)) {
+        lineCount += 1;
+        lineTop = rect.top;
+        lineBottom = rect.bottom;
+      } else {
+        lineTop = Math.min(lineTop, rect.top);
+        lineBottom = Math.max(lineBottom, rect.bottom);
+      }
     }
 
     if (lineLimit !== undefined && lineCount > lineLimit) {
@@ -167,7 +316,10 @@ function measureSequence(
       };
     }
 
-    if (clipToRootHeight && (top < visibleTop - 0.5 || bottom > visibleBottom + 0.5)) {
+    if (
+      clipToRootHeight &&
+      (rect.top < visibleTop - layoutTolerance || rect.bottom > visibleBottom + layoutTolerance)
+    ) {
       // maxHeight can reject a sequence even when the line count is acceptable.
       return {
         allFit: false,
@@ -176,6 +328,7 @@ function measureSequence(
     }
 
     if (part === "item") {
+      options.recordItemWidth?.(visibleItems, rect.width);
       visibleItems += 1;
     }
   }
@@ -199,11 +352,14 @@ export const WrapClamp = defineComponent({
     const afterRef = ref<HTMLElement | null>(null);
     const expanded = ref(expandedProp);
     const visibleCount = ref(initialItems.length);
+    const materializedCount = ref(0);
     const isClamped = ref(false);
 
     let resizeObserver: ResizeObserver | null = null;
     let stopFonts = () => {};
     let lastLayoutSignature: string | null = null;
+    let lastRootWidth: number | null = null;
+    let measuredItemWidths: number[] = [];
 
     function expand(): void {
       expanded.value = true;
@@ -224,11 +380,13 @@ export const WrapClamp = defineComponent({
       const nextClamped = normalizedVisibleCount < totalItems;
       const changed =
         visibleCount.value !== normalizedVisibleCount || isClamped.value !== nextClamped;
+      const materializedChanged = materializedCount.value !== 0;
 
       visibleCount.value = normalizedVisibleCount;
+      materializedCount.value = 0;
       isClamped.value = nextClamped;
 
-      if (changed) {
+      if (changed || materializedChanged) {
         // Measurement reads the rendered item sequence, so each visible-count
         // change must be committed before the next probe.
         await nextTick();
@@ -244,14 +402,399 @@ export const WrapClamp = defineComponent({
       );
     }
 
+    function canUseStaticFlowCountHint(
+      limits: ClampLimits,
+    ): limits is ClampLimits & { lineLimit: number } {
+      return (
+        slots.before === undefined &&
+        slots.after === undefined &&
+        !limits.clipToRootHeight &&
+        limits.lineLimit !== undefined
+      );
+    }
+
+    function canUseStaticFlowSearch(limits: ClampLimits): boolean {
+      return (
+        slots.after === undefined && (limits.lineLimit !== undefined || limits.clipToRootHeight)
+      );
+    }
+
+    function renderedItemElements(): HTMLElement[] {
+      const contentElement = contentRef.value;
+      if (!contentElement) {
+        return [];
+      }
+
+      const elements: HTMLElement[] = [];
+      for (const child of contentElement.children) {
+        if (child instanceof HTMLElement && child.dataset.part === "item") {
+          elements.push(child);
+        }
+      }
+
+      return elements;
+    }
+
+    function showItemCandidate(
+      itemElements: readonly HTMLElement[],
+      currentCount: number,
+      nextCount: number,
+    ): number {
+      const start = Math.min(currentCount, nextCount);
+      const end = Math.max(currentCount, nextCount);
+
+      for (let index = start; index < end; index += 1) {
+        const element = itemElements[index];
+        if (element) {
+          element.style.display = index < nextCount ? "inline-flex" : "none";
+        }
+      }
+
+      return nextCount;
+    }
+
+    function measureCurrentSequence(
+      rootElement: HTMLElement,
+      limits: ClampLimits,
+    ): SequenceMeasurement {
+      const { clipToRootHeight, lineLimit } = limits;
+      if (lineLimit === undefined && (slots.after !== undefined || !clipToRootHeight)) {
+        return measureSequence(rootElement, contentRef.value, limits);
+      }
+
+      const nextWidths = measuredItemWidths.slice(0, props.items.length);
+      const measurement = measureSequence(rootElement, contentRef.value, limits, {
+        recordItemWidth(index, width) {
+          nextWidths[index] = width;
+        },
+      });
+      measuredItemWidths = nextWidths;
+
+      return measurement;
+    }
+
+    function estimateVisibleCountFromWidths(
+      containerWidth: number,
+      lineLimit: number,
+      totalItems: number,
+      beforeWidth = 0,
+    ): number | null {
+      const result = simulateStaticFlow({
+        beforeWidth,
+        containerWidth,
+        itemCount: totalItems,
+        itemWidth: (index) => measuredItemWidths[index] ?? null,
+        lineLimit,
+      });
+
+      return result.status === "unknown" && result.fitCount === 0 ? null : result.fitCount;
+    }
+
+    function averageMeasuredItemWidth(): number | null {
+      let widthSum = 0;
+      let widthCount = 0;
+
+      for (const itemWidth of measuredItemWidths) {
+        if (isPositiveFiniteSize(itemWidth)) {
+          widthSum += itemWidth;
+          widthCount += 1;
+        }
+      }
+
+      return widthCount > 0 ? widthSum / widthCount : null;
+    }
+
+    function visibleAtomicHeight(): number | null {
+      const contentElement = contentRef.value;
+      if (!contentElement) {
+        return null;
+      }
+
+      let height = 0;
+      for (const child of contentElement.children) {
+        if (!(child instanceof HTMLElement)) {
+          continue;
+        }
+
+        const part = child.dataset.part;
+        if (part !== "before" && part !== "item") {
+          continue;
+        }
+
+        const rect = child.getBoundingClientRect();
+        if (!isPositiveFiniteSize(rect.width) || !isPositiveFiniteSize(rect.height)) {
+          continue;
+        }
+
+        height = Math.max(height, rect.height);
+        if (part === "item") {
+          break;
+        }
+      }
+
+      return height > 0 ? height : null;
+    }
+
+    function estimateMaterializedGrowLineLimit(
+      rootElement: HTMLElement,
+      limits: ClampLimits,
+    ): number | null {
+      const { clipToRootHeight, lineLimit } = limits;
+      if (!clipToRootHeight) {
+        return lineLimit ?? null;
+      }
+
+      const atomicHeight = visibleAtomicHeight();
+      if (atomicHeight === null || rootElement.clientHeight <= 0) {
+        return lineLimit ?? null;
+      }
+
+      const clipLineLimit = Math.max(
+        1,
+        Math.floor((rootElement.clientHeight + layoutTolerance) / atomicHeight),
+      );
+
+      return lineLimit === undefined ? clipLineLimit : Math.min(lineLimit, clipLineLimit);
+    }
+
+    function estimateMaterializedFrontierFromWidths(
+      containerWidth: number,
+      lineLimit: number,
+      totalItems: number,
+      fallbackItemWidth: number,
+      beforeWidth: number,
+    ): number {
+      const result = simulateStaticFlow({
+        beforeWidth,
+        containerWidth,
+        itemCount: totalItems,
+        itemWidth: (index) => itemWidthAt(index, fallbackItemWidth),
+        lineLimit,
+      });
+
+      // Include the first predicted overflow item so DOM search has an overflow
+      // side instead of accepting a too-low upper bound.
+      return result.status === "overflow" ? Math.min(totalItems, result.fitCount + 1) : totalItems;
+    }
+
+    function estimateMaterializedGrowCount(
+      containerWidth: number,
+      lineLimit: number,
+      currentVisibleCount: number,
+      totalItems: number,
+      beforeWidth = 0,
+    ): number {
+      const averageItemWidth = averageMeasuredItemWidth();
+      // The extra item gives DOM search an overflow side when the estimate
+      // lands exactly on the fitting frontier.
+      let estimatedFrontierCount = fallbackMaterializedGrowItems;
+      if (averageItemWidth !== null) {
+        estimatedFrontierCount = estimateMaterializedFrontierFromWidths(
+          containerWidth,
+          lineLimit,
+          totalItems,
+          averageItemWidth,
+          beforeWidth,
+        );
+      }
+      const materializationCap = Math.max(
+        fallbackMaterializedGrowItems,
+        lineLimit * maxMaterializedGrowItemsPerLine,
+      );
+      const cappedTargetCount = Math.min(estimatedFrontierCount, materializationCap);
+
+      return Math.min(totalItems, Math.max(currentVisibleCount + 1, cappedTargetCount));
+    }
+
+    function itemWidthAt(index: number, fallbackWidth: number): number {
+      const measuredWidth = measuredItemWidths[index];
+      return isPositiveFiniteSize(measuredWidth) ? measuredWidth : fallbackWidth;
+    }
+
+    function estimateDynamicAfterGrowHintCount(
+      containerWidth: number,
+      lineLimit: number,
+      totalItems: number,
+      averageItemWidth: number,
+      beforeWidth: number,
+      afterWidth: number,
+      hint: number,
+    ): number {
+      return findLargestFittingCount(
+        0,
+        totalItems,
+        (candidate) =>
+          simulateStaticFlow({
+            afterWidth,
+            beforeWidth,
+            containerWidth,
+            itemCount: candidate,
+            itemWidth: (index) => itemWidthAt(index, averageItemWidth),
+            lineLimit,
+          }).status === "fit",
+        hint,
+      );
+    }
+
+    async function applyStaticFlowCountHint(
+      containerWidth: number,
+      limits: ClampLimits,
+    ): Promise<void> {
+      const { items } = props;
+      if (!canUseStaticFlowCountHint(limits)) {
+        return;
+      }
+
+      const estimatedVisibleCount = estimateVisibleCountFromWidths(
+        containerWidth,
+        limits.lineLimit,
+        items.length,
+      );
+
+      if (estimatedVisibleCount !== null && estimatedVisibleCount !== visibleCount.value) {
+        await applyVisibleCount(estimatedVisibleCount);
+      }
+    }
+
+    async function applyStaticFlowShrink(
+      rootElement: HTMLElement,
+      limits: ClampLimits,
+    ): Promise<boolean> {
+      if (!canUseStaticFlowSearch(limits)) {
+        return false;
+      }
+
+      const beforeSize = measureElementSize(beforeRef.value);
+      const measurement = measureCurrentSequence(rootElement, limits);
+      if (measurement.allFit || measurement.visibleItems >= visibleCount.value) {
+        return false;
+      }
+
+      await applyVisibleCount(measurement.visibleItems);
+
+      const nextBeforeSize = measureElementSize(beforeRef.value);
+      const verification = measureCurrentSequence(rootElement, limits);
+      return (
+        verification.allFit &&
+        verification.visibleItems === visibleCount.value &&
+        isSameSize(beforeSize, nextBeforeSize)
+      );
+    }
+
+    async function applyStaticFlowMaterializedGrow(
+      rootElement: HTMLElement,
+      rootWidth: number,
+      limits: ClampLimits,
+    ): Promise<boolean> {
+      const { items } = props;
+      if (!canUseStaticFlowSearch(limits)) {
+        return false;
+      }
+
+      const currentVisibleCount = visibleCount.value;
+      const totalItems = items.length;
+      const beforeSize = measureElementSize(beforeRef.value);
+      const searchLineLimit = estimateMaterializedGrowLineLimit(rootElement, limits);
+      if (searchLineLimit === null) {
+        return false;
+      }
+
+      const searchItemCount = estimateMaterializedGrowCount(
+        rootWidth,
+        searchLineLimit,
+        currentVisibleCount,
+        totalItems,
+        beforeSize?.width,
+      );
+      if (currentVisibleCount >= searchItemCount) {
+        return false;
+      }
+
+      // The no-after grow path materializes a bounded suffix once, then toggles
+      // component-owned item shells during search. User slots are not rerun for
+      // every candidate.
+      materializedCount.value = searchItemCount;
+      await nextTick();
+
+      const itemElements = renderedItemElements();
+      const contentElement = contentRef.value;
+      if (!contentElement || itemElements.length < searchItemCount) {
+        await applyVisibleCount(currentVisibleCount);
+        return false;
+      }
+
+      let shownCount = currentVisibleCount;
+      const bestFitCount = findLargestFittingCount(
+        currentVisibleCount,
+        searchItemCount,
+        (candidate) => {
+          shownCount = showItemCandidate(itemElements, shownCount, candidate);
+
+          const measurement = measureSequence(rootElement, contentElement, limits);
+          return measurement.allFit && measurement.visibleItems === candidate;
+        },
+      );
+
+      showItemCandidate(itemElements, shownCount, currentVisibleCount);
+      await applyVisibleCount(bestFitCount);
+
+      const reachedSearchLimit = bestFitCount === searchItemCount && searchItemCount < totalItems;
+      const nextBeforeSize = measureElementSize(beforeRef.value);
+      const verification = measureCurrentSequence(rootElement, limits);
+      return (
+        verification.allFit &&
+        verification.visibleItems === visibleCount.value &&
+        isSameSize(beforeSize, nextBeforeSize) &&
+        !reachedSearchLimit
+      );
+    }
+
+    async function applyDynamicAfterGrowHint(
+      rootWidth: number,
+      rootWidthDelta: number,
+      limits: ClampLimits,
+    ): Promise<void> {
+      const { items } = props;
+      if (
+        slots.after === undefined ||
+        limits.clipToRootHeight ||
+        limits.lineLimit === undefined ||
+        visibleCount.value >= items.length
+      ) {
+        return;
+      }
+
+      const averageItemWidth = averageMeasuredItemWidth();
+      if (averageItemWidth === null || rootWidthDelta < averageItemWidth - layoutTolerance) {
+        return;
+      }
+
+      const beforeSize = measureElementSize(beforeRef.value);
+      const afterSize = measureElementSize(afterRef.value);
+      const estimatedVisibleCount = estimateDynamicAfterGrowHintCount(
+        rootWidth,
+        limits.lineLimit,
+        items.length,
+        averageItemWidth,
+        beforeSize?.width ?? 0,
+        afterSize?.width ?? 0,
+        visibleCount.value,
+      );
+
+      if (estimatedVisibleCount <= visibleCount.value + 1 || estimatedVisibleCount > items.length) {
+        return;
+      }
+
+      await applyVisibleCount(estimatedVisibleCount);
+    }
+
     async function settleVisibleCount(
       rootElement: HTMLElement,
-      lineLimit: number | undefined,
-      clipToRootHeight: boolean,
+      limits: ClampLimits,
     ): Promise<void> {
       const { items } = props;
       const totalItems = items.length;
-      let measurement = measureSequence(rootElement, contentRef.value, lineLimit, clipToRootHeight);
+      let measurement = measureCurrentSequence(rootElement, limits);
 
       while (
         visibleCount.value > 0 &&
@@ -260,7 +803,7 @@ export const WrapClamp = defineComponent({
         // First shrink to a known fitting prefix. Measurement may report fewer
         // visible items than requested when before/after slots consume space.
         await applyVisibleCount(Math.min(measurement.visibleItems, visibleCount.value - 1));
-        measurement = measureSequence(rootElement, contentRef.value, lineLimit, clipToRootHeight);
+        measurement = measureCurrentSequence(rootElement, limits);
       }
 
       while (
@@ -272,7 +815,7 @@ export const WrapClamp = defineComponent({
         // Then grow one item at a time to recover space after width increases.
         // Linear growth is deliberate because each item can have arbitrary width.
         await applyVisibleCount(currentVisibleCount + 1);
-        measurement = measureSequence(rootElement, contentRef.value, lineLimit, clipToRootHeight);
+        measurement = measureCurrentSequence(rootElement, limits);
 
         if (!measurement.allFit || measurement.visibleItems < currentVisibleCount + 1) {
           await applyVisibleCount(currentVisibleCount);
@@ -284,11 +827,16 @@ export const WrapClamp = defineComponent({
     async function recompute(): Promise<void> {
       const { items, maxHeight, maxLines } = props;
       const totalItems = items.length;
-      const lineLimit = normalizeLineLimit(maxLines);
-      const clipToRootHeight = maxHeight !== undefined;
-      const hasLimit = lineLimit !== undefined || clipToRootHeight;
+      const limits: ClampLimits = {
+        clipToRootHeight: maxHeight !== undefined,
+        lineLimit: normalizeLineLimit(maxLines),
+      };
 
-      if (expanded.value || totalItems === 0 || !hasLimit) {
+      if (
+        expanded.value ||
+        totalItems === 0 ||
+        (limits.lineLimit === undefined && !limits.clipToRootHeight)
+      ) {
         // Without an active clamp constraint, render the full item list so slot
         // props and DOM order stay straightforward.
         await applyVisibleCount(totalItems);
@@ -296,14 +844,40 @@ export const WrapClamp = defineComponent({
       }
 
       const rootElement = rootRef.value;
-      if (!rootElement || rootElement.getBoundingClientRect().width <= 0) {
+      const rootWidth = rootElement?.getBoundingClientRect().width ?? 0;
+      if (!rootElement || rootWidth <= 0) {
         // Hidden or unmounted roots cannot produce stable item measurements.
+        lastRootWidth = null;
         await applyVisibleCount(totalItems);
         return;
       }
 
+      const previousRootWidth = lastRootWidth;
+      const rootWidthDelta = previousRootWidth === null ? 0 : rootWidth - previousRootWidth;
+      const rootWidthShrank = rootWidthDelta < -layoutTolerance;
+      const rootWidthGrew = rootWidthDelta > layoutTolerance;
+      lastRootWidth = rootWidth;
+
       await applyVisibleCount(Math.min(visibleCount.value, totalItems));
-      await settleVisibleCount(rootElement, lineLimit, clipToRootHeight);
+      // Fast paths are ordered from cheapest proof to most speculative hint.
+      // Any rejected path falls through to live-DOM settlement below.
+      if (rootWidthShrank && (await applyStaticFlowShrink(rootElement, limits))) {
+        return;
+      }
+
+      await applyStaticFlowCountHint(rootWidth, limits);
+      if (
+        rootWidthGrew &&
+        (await applyStaticFlowMaterializedGrow(rootElement, rootWidth, limits))
+      ) {
+        return;
+      }
+
+      if (rootWidthGrew) {
+        await applyDynamicAfterGrowHint(rootWidth, rootWidthDelta, limits);
+      }
+
+      await settleVisibleCount(rootElement, limits);
     }
 
     const requestRecompute = createCoalescingRunner(async () => {
@@ -333,6 +907,7 @@ export const WrapClamp = defineComponent({
     watch(
       [() => props.maxLines, () => props.maxHeight, () => props.itemKey, () => props.items],
       () => {
+        measuredItemWidths = [];
         requestRecompute();
       },
       { deep: true, flush: "post" },
@@ -355,9 +930,19 @@ export const WrapClamp = defineComponent({
         }
       });
 
-      const observed = [rootRef.value, contentRef.value, beforeRef.value, afterRef.value].filter(
-        (element): element is HTMLElement => element instanceof HTMLElement,
-      );
+      const observed: HTMLElement[] = [];
+      if (rootRef.value instanceof HTMLElement) {
+        observed.push(rootRef.value);
+      }
+      if (contentRef.value instanceof HTMLElement) {
+        observed.push(contentRef.value);
+      }
+      if (beforeRef.value instanceof HTMLElement) {
+        observed.push(beforeRef.value);
+      }
+      if (afterRef.value instanceof HTMLElement) {
+        observed.push(afterRef.value);
+      }
 
       for (const element of observed) {
         resizeObserver.observe(element);
@@ -372,7 +957,10 @@ export const WrapClamp = defineComponent({
 
     onMounted(() => {
       requestRecompute();
-      stopFonts = listenForFontLoads(requestRecompute);
+      stopFonts = listenForFontLoads(() => {
+        measuredItemWidths = [];
+        requestRecompute();
+      });
     });
 
     onBeforeUnmount(() => {
@@ -396,16 +984,24 @@ export const WrapClamp = defineComponent({
       const { as, itemKey, items, maxHeight } = props;
       const collapsedMaxHeight = !expanded.value ? cssLength(maxHeight) : undefined;
       const renderedVisibleCount = Math.min(visibleCount.value, items.length);
-      const slotProps: WrapClampSlotProps = {
-        expand,
-        collapse,
-        toggle,
-        clamped: renderedVisibleCount < items.length,
-        expanded: expanded.value,
-        hiddenItems: items.slice(renderedVisibleCount),
-      };
-      const beforeSlot = slots.before?.(slotProps);
-      const afterSlot = slots.after?.(slotProps);
+      const renderedItemCount = Math.min(
+        items.length,
+        Math.max(renderedVisibleCount, materializedCount.value),
+      );
+      const hasAffixSlot = slots.before !== undefined || slots.after !== undefined;
+      const slotProps = hasAffixSlot
+        ? ({
+            expand,
+            collapse,
+            toggle,
+            clamped: renderedVisibleCount < items.length,
+            expanded: expanded.value,
+            hiddenItems: items.slice(renderedVisibleCount),
+          } satisfies WrapClampSlotProps)
+        : undefined;
+      const beforeSlot = slotProps === undefined ? undefined : slots.before?.(slotProps);
+      const afterSlot = slotProps === undefined ? undefined : slots.after?.(slotProps);
+
       const children: VNodeChild[] = [];
 
       if (hasSlotContent(beforeSlot)) {
@@ -422,22 +1018,25 @@ export const WrapClamp = defineComponent({
         );
       }
 
-      for (let index = 0; index < renderedVisibleCount; index += 1) {
+      for (let index = 0; index < renderedItemCount; index += 1) {
         const item = items[index];
-        const itemSlotProps: WrapClampItemSlotProps = {
-          item,
-          index,
-        };
+        const hiddenProbeItem = index >= renderedVisibleCount;
+        const itemContent =
+          slots.item?.({
+            item,
+            index,
+          } satisfies WrapClampItemSlotProps) ?? defaultItemText(item);
 
         children.push(
           h(
             "span",
             {
+              "aria-hidden": hiddenProbeItem ? "true" : undefined,
               "data-part": "item",
               key: resolveItemKey(itemKey, item, index),
-              style: itemStyle,
+              style: hiddenProbeItem ? hiddenItemStyle : itemStyle,
             },
-            slots.item?.(itemSlotProps) ?? defaultItemText(item),
+            itemContent,
           ),
         );
       }

--- a/packages/vue-clamp/src/WrapClamp.ts
+++ b/packages/vue-clamp/src/WrapClamp.ts
@@ -20,8 +20,13 @@ import { blockAsProp, expandedProp, maxHeightProp, maxLinesProp } from "./props.
 import { findLargestFittingCount } from "./search.ts";
 import { hasSlotContent } from "./slot.ts";
 
-import type { CSSProperties, PropType, VNodeChild } from "vue";
-import type { WrapClampExposed, WrapClampItemSlotProps, WrapClampSlotProps } from "./types.ts";
+import type { CSSProperties, PropType, SlotsType, VNodeChild } from "vue";
+import type {
+  WrapClampExposed,
+  WrapClampItemSlotProps,
+  WrapClampSlotProps,
+  WrapClampSlots,
+} from "./types.ts";
 
 type ItemKeyResolver = (item: unknown, index: number) => string | number;
 type SequenceMeasurement = {
@@ -344,6 +349,7 @@ export const WrapClamp = defineComponent({
   inheritAttrs: false,
   props: propsDef,
   emits: emitsDef,
+  slots: Object as SlotsType<WrapClampSlots>,
   setup(props, { attrs, emit, expose, slots }) {
     const { expanded: expandedProp, items: initialItems } = props;
     const rootRef = ref<HTMLElement | null>(null);

--- a/packages/vue-clamp/src/index.ts
+++ b/packages/vue-clamp/src/index.ts
@@ -7,6 +7,7 @@ export { WrapClamp } from "./WrapClamp.ts";
 
 export type {
   ClampBoundary,
+  ClampLength,
   InlineClampParts,
   InlineClampProps,
   InlineClampSplit,

--- a/packages/vue-clamp/src/layout.ts
+++ b/packages/vue-clamp/src/layout.ts
@@ -1,3 +1,5 @@
+import type { ClampLength } from "./types.ts";
+
 export function normalizeLineLimit(maxLines: number | undefined): number | undefined {
   if (maxLines === undefined || !Number.isFinite(maxLines) || maxLines <= 0) {
     return undefined;
@@ -39,7 +41,7 @@ export function createCoalescingRunner(task: () => Promise<void>): () => void {
   };
 }
 
-export function cssLength(value: number | string | undefined): string | number | undefined {
+export function cssLength(value: ClampLength | undefined): string | undefined {
   return typeof value === "number" ? `${value}px` : value;
 }
 
@@ -83,7 +85,7 @@ export function fitsContent(
   rootElement: HTMLElement,
   contentElement: HTMLElement,
   lineLimit: number | undefined,
-  maxHeight: number | string | undefined,
+  maxHeight: ClampLength | undefined,
 ): boolean {
   if (lineLimit === undefined && maxHeight === undefined) {
     // No visual limit means every candidate fits; avoid layout reads entirely.

--- a/packages/vue-clamp/src/multiline.ts
+++ b/packages/vue-clamp/src/multiline.ts
@@ -3,30 +3,37 @@ import { combinedSizeSignature, createCoalescingRunner, listenForFontLoads } fro
 
 import type { Ref } from "vue";
 
-type FrameRefs = {
-  rootRef: Ref<HTMLElement | null>;
-  contentRef: Ref<HTMLElement | null>;
-  beforeRef: Ref<HTMLElement | null>;
-  bodyRef: Ref<HTMLElement | null>;
-  afterRef: Ref<HTMLElement | null>;
+export type MultilineClampFrameRefs = {
+  readonly rootRef: Ref<HTMLElement | null>;
+  readonly contentRef: Ref<HTMLElement | null>;
+  readonly beforeRef: Ref<HTMLElement | null>;
+  readonly bodyRef: Ref<HTMLElement | null>;
+  readonly afterRef: Ref<HTMLElement | null>;
 };
 
-type ShellState = FrameRefs & {
-  expanded: Ref<boolean>;
-  isClamped: Ref<boolean>;
+type ShellState = MultilineClampFrameRefs & {
+  readonly expanded: Ref<boolean>;
+  readonly isClamped: Ref<boolean>;
 };
 
-type ShellOptions = {
-  getExpanded: () => boolean;
-  onExpandedChange: (value: boolean) => void;
-  onClampedChange: (value: boolean) => void;
-  recompute: (expanded: Ref<boolean>) => Promise<void>;
+export type MultilineClampShellOptions = {
+  readonly getExpanded: () => boolean;
+  readonly onExpandedChange: (value: boolean) => void;
+  readonly onClampedChange: (value: boolean) => void;
+  readonly recompute: (expanded: Ref<boolean>) => Promise<void>;
+};
+
+export type MultilineClampShell = ShellState & {
+  readonly expand: () => void;
+  readonly collapse: () => void;
+  readonly toggle: () => void;
+  readonly requestRecompute: () => void;
 };
 
 // LineClamp and RichLineClamp have different clamp engines but the same shell:
 // controlled expansion, slot/root refs, invalidation sources, and event timing.
 // Keeping that shell here avoids two subtly divergent lifecycle implementations.
-export function useMultilineClamp(options: ShellOptions) {
+export function useMultilineClamp(options: MultilineClampShellOptions): MultilineClampShell {
   const { getExpanded, onExpandedChange, onClampedChange, recompute } = options;
   const state: ShellState = {
     rootRef: ref<HTMLElement | null>(null),

--- a/packages/vue-clamp/src/native.ts
+++ b/packages/vue-clamp/src/native.ts
@@ -1,16 +1,16 @@
 import type { CSSProperties } from "vue";
 import type { ClampBoundary, ClampLength } from "./types.ts";
 
-type NativeClampMode = "single-line" | "multi-line";
+export type NativeClampMode = "single-line" | "multi-line";
 
-type NativeModeInput = {
-  boundary: ClampBoundary;
-  ellipsis: string;
-  expanded: boolean;
-  hasAfterSlot: boolean;
-  lineLimit: number | undefined;
-  locationRatio: number;
-  maxHeight: ClampLength | undefined;
+export type NativeModeInput = {
+  readonly boundary: ClampBoundary;
+  readonly ellipsis: string;
+  readonly expanded: boolean;
+  readonly hasAfterSlot: boolean;
+  readonly lineLimit: number | undefined;
+  readonly locationRatio: number;
+  readonly maxHeight: ClampLength | undefined;
 };
 
 let supportsMultilineClamp: boolean | null = null;

--- a/packages/vue-clamp/src/native.ts
+++ b/packages/vue-clamp/src/native.ts
@@ -1,7 +1,7 @@
 import type { CSSProperties } from "vue";
-import type { ClampBoundary } from "./types.ts";
+import type { ClampBoundary, ClampLength } from "./types.ts";
 
-export type NativeClampMode = "single-line" | "multi-line";
+type NativeClampMode = "single-line" | "multi-line";
 
 type NativeModeInput = {
   boundary: ClampBoundary;
@@ -10,7 +10,7 @@ type NativeModeInput = {
   hasAfterSlot: boolean;
   lineLimit: number | undefined;
   locationRatio: number;
-  maxHeight: number | string | undefined;
+  maxHeight: ClampLength | undefined;
 };
 
 let supportsMultilineClamp: boolean | null = null;

--- a/packages/vue-clamp/src/props.ts
+++ b/packages/vue-clamp/src/props.ts
@@ -1,5 +1,5 @@
 import type { PropType } from "vue";
-import type { ClampBoundary, LineClampLocation } from "./types.ts";
+import type { ClampBoundary, ClampLength, LineClampLocation } from "./types.ts";
 
 // Shared prop definitions keep runtime validators and defaults consistent across
 // the components that expose the same public API concepts.
@@ -43,6 +43,6 @@ export const locationProp = {
   },
 } as const;
 
-export const maxHeightProp = [Number, String] as PropType<number | string | undefined>;
+export const maxHeightProp = [Number, String] as PropType<ClampLength | undefined>;
 
 export const maxLinesProp = Number;

--- a/packages/vue-clamp/src/rich.ts
+++ b/packages/vue-clamp/src/rich.ts
@@ -2,7 +2,7 @@ import { fitsContent } from "./layout.ts";
 import { findLastFittingIndex } from "./search.ts";
 import { prepareText } from "./text.ts";
 
-import type { ClampBoundary } from "./types.ts";
+import type { ClampBoundary, ClampLength } from "./types.ts";
 
 // Rich clamping is structural rather than string-based. We parse once, measure
 // candidate DOM fragments, and patch structural states back into visible/probe DOM.
@@ -82,7 +82,7 @@ type ClampOptions = {
   from: RichState | null;
   hint: RichState | null;
   lineLimit: number | undefined;
-  maxHeight: number | string | undefined;
+  maxHeight: ClampLength | undefined;
   prepared: PreparedRich;
   probe: Probe;
 };

--- a/packages/vue-clamp/src/rich.ts
+++ b/packages/vue-clamp/src/rich.ts
@@ -6,27 +6,29 @@ import type { ClampBoundary, ClampLength } from "./types.ts";
 
 // Rich clamping is structural rather than string-based. We parse once, measure
 // candidate DOM fragments, and patch structural states back into visible/probe DOM.
-type BoundaryPoint = {
-  path: readonly number[];
-  offset: number;
+export type RichBoundaryPoint = {
+  readonly path: readonly number[];
+  readonly offset: number;
 };
 
-type PreparedTextNode = {
-  kind: "text";
-  endPoint: BoundaryPoint;
-  textCuts: readonly BoundaryPoint[];
-  fallbackTextCuts?: readonly BoundaryPoint[];
+type BoundaryPoint = RichBoundaryPoint;
+
+export type PreparedRichTextNode = {
+  readonly kind: "text";
+  readonly endPoint: RichBoundaryPoint;
+  readonly textCuts: readonly RichBoundaryPoint[];
+  readonly fallbackTextCuts?: readonly RichBoundaryPoint[];
 };
 
-type PreparedElementNode = {
-  kind: "element";
-  pathKey: string;
-  isBreak: boolean;
-  endPoint: BoundaryPoint;
-  children: readonly PreparedRichNode[];
+export type PreparedRichElementNode = {
+  readonly kind: "element";
+  readonly pathKey: string;
+  readonly isBreak: boolean;
+  readonly endPoint: RichBoundaryPoint;
+  readonly children: readonly PreparedRichNode[];
 };
 
-type PreparedRichNode = PreparedTextNode | PreparedElementNode;
+export type PreparedRichNode = PreparedRichTextNode | PreparedRichElementNode;
 
 type LogicalRun =
   | {
@@ -41,19 +43,19 @@ type LogicalRun =
     };
 
 export type PreparedRich = {
-  root: HTMLElement;
-  nodes: readonly PreparedRichNode[];
+  readonly root: HTMLElement;
+  readonly nodes: readonly PreparedRichNode[];
 };
 
 // States are kept as structural points so width-only reclamps can patch from the
 // previous DOM state without serializing and reparsing HTML.
 export type RichState =
   | {
-      kind: "full";
+      readonly kind: "full";
     }
   | {
-      kind: "clamped";
-      point: BoundaryPoint;
+      readonly kind: "clamped";
+      readonly point: RichBoundaryPoint;
     };
 
 type BoundaryPosition = {
@@ -66,25 +68,25 @@ type PatchAnchor = {
   startIndex: number;
 };
 
-type ClampResult = {
-  fallback: boolean;
-  state: RichState | null;
+export type RichClampProbe = {
+  readonly body: HTMLElement;
+  readonly content: HTMLElement;
+  readonly root: HTMLElement;
 };
 
-type Probe = {
-  body: HTMLElement;
-  content: HTMLElement;
-  root: HTMLElement;
+export type RichClampOptions = {
+  readonly ellipsis: string;
+  readonly from: RichState | null;
+  readonly hint: RichState | null;
+  readonly lineLimit: number | undefined;
+  readonly maxHeight: ClampLength | undefined;
+  readonly prepared: PreparedRich;
+  readonly probe: RichClampProbe;
 };
 
-type ClampOptions = {
-  ellipsis: string;
-  from: RichState | null;
-  hint: RichState | null;
-  lineLimit: number | undefined;
-  maxHeight: ClampLength | undefined;
-  prepared: PreparedRich;
-  probe: Probe;
+export type RichClampResult = {
+  readonly fallback: boolean;
+  readonly state: RichState | null;
 };
 
 const ROOT_PATH: readonly number[] = [];
@@ -282,7 +284,7 @@ function buildLogicalRuns(
   atomicPaths: ReadonlySet<string>,
 ): LogicalRun[] {
   const runs: LogicalRun[] = [];
-  let currentTextNodes: PreparedTextNode[] = [];
+  let currentTextNodes: PreparedRichTextNode[] = [];
 
   function flushTextRun(): void {
     if (currentTextNodes.length === 0) {
@@ -751,7 +753,7 @@ export function clampRich({
   maxHeight,
   prepared,
   probe,
-}: ClampOptions): ClampResult {
+}: RichClampOptions): RichClampResult {
   const { nodes } = prepared;
   const { body, content, root } = probe;
 

--- a/packages/vue-clamp/src/search.ts
+++ b/packages/vue-clamp/src/search.ts
@@ -28,6 +28,27 @@ function binarySearchLastFit(
   return currentBest;
 }
 
+function binarySearchLargestFittingCount(
+  low: number,
+  high: number,
+  fits: (count: number) => boolean,
+): number {
+  let floor = low;
+  let ceiling = high;
+
+  while (floor < ceiling) {
+    const count = Math.ceil((floor + ceiling) / 2);
+
+    if (fits(count)) {
+      floor = count;
+    } else {
+      ceiling = count - 1;
+    }
+  }
+
+  return floor;
+}
+
 export function findLastFittingIndex(
   count: number,
   fits: (index: number) => boolean,
@@ -94,4 +115,32 @@ export function findLastFittingIndex(
   }
 
   return -1;
+}
+
+export function findLargestFittingCount(
+  low: number,
+  high: number,
+  fits: (count: number) => boolean,
+  hint?: number | null,
+): number {
+  if (high <= low) {
+    return low;
+  }
+
+  if (hint == null || !Number.isFinite(hint)) {
+    // Count searches often mutate DOM in their predicate. Keep the no-hint path
+    // on the original ceil-midpoint probe order so those reads do not regress.
+    return binarySearchLargestFittingCount(low, high, fits);
+  }
+
+  const offsetHint = Math.floor(hint) - low;
+  const fittingOffset = findLastFittingIndex(
+    high - low + 1,
+    (offset) => fits(low + offset),
+    offsetHint,
+  );
+
+  // Count searches are called with a known-safe lower bound. Preserve that
+  // fallback if an unusual predicate rejects every probed candidate.
+  return fittingOffset < 0 ? low : low + fittingOffset;
 }

--- a/packages/vue-clamp/src/slot.ts
+++ b/packages/vue-clamp/src/slot.ts
@@ -2,9 +2,13 @@ import { Comment, Fragment, Text, isVNode } from "vue";
 
 import type { VNodeChild } from "vue";
 
+type PresentSlotContent = Exclude<VNodeChild, null | undefined | void>;
+
 // Slot wrappers affect measurement, so comment-only or whitespace-only slots
 // must be treated as absent instead of rendering empty inline boxes.
-export function hasSlotContent(value: VNodeChild | VNodeChild[] | undefined): boolean {
+export function hasSlotContent(
+  value: VNodeChild | VNodeChild[] | undefined,
+): value is PresentSlotContent {
   if (Array.isArray(value)) {
     return value.some(hasSlotContent);
   }

--- a/packages/vue-clamp/src/text.ts
+++ b/packages/vue-clamp/src/text.ts
@@ -14,44 +14,44 @@ const wordSegmenter = new Intl.Segmenter(undefined, {
 });
 
 export interface PreparedText {
-  text: string;
-  boundary: ClampBoundary;
-  boundaryOffsets: number[];
-  fallbackBoundaryOffsets?: number[];
+  readonly text: string;
+  readonly boundary: ClampBoundary;
+  readonly boundaryOffsets: readonly number[];
+  readonly fallbackBoundaryOffsets?: readonly number[];
 }
 
 export interface TextClampHint {
-  boundaryOffsets: readonly number[];
-  kept: number;
+  readonly boundaryOffsets: readonly number[];
+  readonly kept: number;
 }
 
 export interface TextClampResult extends TextClampHint {
-  text: string;
+  readonly text: string;
 }
 
 type MaybeTextClampHint = TextClampHint | null | undefined;
 
-type Spacing = "trim" | "preserve-outer";
+export type TextClampSpacing = "trim" | "preserve-outer";
 
-type FitInput = {
-  ellipsis: string;
-  fits: (text: string) => boolean;
-  hint?: MaybeTextClampHint;
-  prepared: PreparedText;
-  ratio: number;
-  spacing?: Spacing;
+export type TextClampFitInput = {
+  readonly ellipsis: string;
+  readonly fits: (text: string) => boolean;
+  readonly hint?: MaybeTextClampHint;
+  readonly prepared: PreparedText;
+  readonly ratio: number;
+  readonly spacing?: TextClampSpacing;
 };
 
-type LayoutInput = {
-  content: HTMLElement;
-  ellipsis: string;
-  hint?: MaybeTextClampHint;
-  lineLimit: number | undefined;
-  maxHeight: ClampLength | undefined;
-  prepared: PreparedText;
-  ratio: number;
-  root: HTMLElement;
-  target: HTMLElement;
+export type TextClampLayoutInput = {
+  readonly content: HTMLElement;
+  readonly ellipsis: string;
+  readonly hint?: MaybeTextClampHint;
+  readonly lineLimit: number | undefined;
+  readonly maxHeight: ClampLength | undefined;
+  readonly prepared: PreparedText;
+  readonly ratio: number;
+  readonly root: HTMLElement;
+  readonly target: HTMLElement;
 };
 
 function isAsciiSafe(text: string): boolean {
@@ -139,7 +139,7 @@ export function displayTextForKeptCount(
   ratio: number,
   ellipsis: string,
   kept: number,
-  spacing: Spacing = "trim",
+  spacing: TextClampSpacing = "trim",
 ): string {
   const { boundaryOffsets, text } = prepared;
   const boundaryCount = boundaryOffsets.length - 1;
@@ -193,7 +193,7 @@ export function clampTextToFit({
   prepared,
   ratio,
   spacing = "trim",
-}: FitInput): TextClampResult {
+}: TextClampFitInput): TextClampResult {
   const boundaryCount = prepared.boundaryOffsets.length - 1;
 
   // The search helper works over indexes. For text, the index is the number of
@@ -243,7 +243,7 @@ export function clampTextToLayout({
   ratio,
   root,
   target,
-}: LayoutInput): TextClampResult | null {
+}: TextClampLayoutInput): TextClampResult | null {
   if (root.getBoundingClientRect().width <= 0) {
     // Measuring against an unlaid-out root would only cache a bogus clamp.
     return null;

--- a/packages/vue-clamp/src/text.ts
+++ b/packages/vue-clamp/src/text.ts
@@ -1,7 +1,7 @@
 import { fitsContent } from "./layout.ts";
 import { findLastFittingIndex } from "./search.ts";
 
-import type { ClampBoundary, LineClampLocation } from "./types.ts";
+import type { ClampBoundary, ClampLength, LineClampLocation } from "./types.ts";
 
 // Text preparation is separated from DOM measurement so width-only reclamps can
 // reuse the same boundary list instead of segmenting the source text again.
@@ -20,18 +20,23 @@ export interface PreparedText {
   fallbackBoundaryOffsets?: number[];
 }
 
-export interface TextClampResult {
+export interface TextClampHint {
   boundaryOffsets: readonly number[];
   kept: number;
+}
+
+export interface TextClampResult extends TextClampHint {
   text: string;
 }
+
+type MaybeTextClampHint = TextClampHint | null | undefined;
 
 type Spacing = "trim" | "preserve-outer";
 
 type FitInput = {
   ellipsis: string;
   fits: (text: string) => boolean;
-  hint?: { boundaryOffsets: readonly number[]; kept: number } | null | undefined;
+  hint?: MaybeTextClampHint;
   prepared: PreparedText;
   ratio: number;
   spacing?: Spacing;
@@ -40,9 +45,9 @@ type FitInput = {
 type LayoutInput = {
   content: HTMLElement;
   ellipsis: string;
-  hint?: { boundaryOffsets: readonly number[]; kept: number } | null | undefined;
+  hint?: MaybeTextClampHint;
   lineLimit: number | undefined;
-  maxHeight: number | string | undefined;
+  maxHeight: ClampLength | undefined;
   prepared: PreparedText;
   ratio: number;
   root: HTMLElement;

--- a/packages/vue-clamp/src/types.ts
+++ b/packages/vue-clamp/src/types.ts
@@ -99,12 +99,6 @@ export interface WrapClampSlotProps<T = unknown> extends ClampSlotProps {
   hiddenItems: readonly T[];
 }
 
-export interface WrapClampSlots<T = unknown> {
-  item?: ClampSlotRender<WrapClampItemSlotProps<T>>;
-  before?: ClampSlotRender<WrapClampSlotProps<T>>;
-  after?: ClampSlotRender<WrapClampSlotProps<T>>;
-}
-
 export type WrapClampExposed = ClampExposed;
 
 export interface WrapClampProps<T = unknown> {

--- a/packages/vue-clamp/src/types.ts
+++ b/packages/vue-clamp/src/types.ts
@@ -1,10 +1,16 @@
-// Public declarations live in one module so consumers and the runtime prop
+import type { VNodeChild } from "vue";
+
+// Package API declarations live in one module so consumers and the runtime prop
 // definitions stay aligned without importing component implementation files.
+// Private building blocks below keep concrete component contracts consistent
+// without becoming package-level names themselves.
 export type ClampBoundary = "grapheme" | "word";
 
 export type ClampLength = number | string;
 
 export type LineClampLocation = "start" | "middle" | "end" | number;
+
+type ClampSlotRender<Props> = (props: Props) => VNodeChild;
 
 // Multiline text/rich and wrap clamps expose the same imperative shell so slot
 // controls can be shared across components.
@@ -30,6 +36,11 @@ export type LineClampSlotProps = ClampSlotProps;
 
 export type LineClampExposed = ClampExposed;
 
+export interface LineClampSlots {
+  before?: ClampSlotRender<LineClampSlotProps>;
+  after?: ClampSlotRender<LineClampSlotProps>;
+}
+
 export interface LineClampProps {
   as?: string;
   text?: string;
@@ -54,6 +65,11 @@ export interface RichLineClampProps {
 export type RichLineClampSlotProps = ClampSlotProps;
 
 export type RichLineClampExposed = ClampExposed;
+
+export interface RichLineClampSlots {
+  before?: ClampSlotRender<RichLineClampSlotProps>;
+  after?: ClampSlotRender<RichLineClampSlotProps>;
+}
 
 export interface InlineClampParts {
   start?: string;
@@ -81,6 +97,12 @@ export interface WrapClampItemSlotProps<T = unknown> {
 
 export interface WrapClampSlotProps<T = unknown> extends ClampSlotProps {
   hiddenItems: readonly T[];
+}
+
+export interface WrapClampSlots<T = unknown> {
+  item?: ClampSlotRender<WrapClampItemSlotProps<T>>;
+  before?: ClampSlotRender<WrapClampSlotProps<T>>;
+  after?: ClampSlotRender<WrapClampSlotProps<T>>;
 }
 
 export type WrapClampExposed = ClampExposed;

--- a/packages/vue-clamp/src/types.ts
+++ b/packages/vue-clamp/src/types.ts
@@ -2,6 +2,8 @@
 // definitions stay aligned without importing component implementation files.
 export type ClampBoundary = "grapheme" | "word";
 
+export type ClampLength = number | string;
+
 export type LineClampLocation = "start" | "middle" | "end" | number;
 
 // Multiline text/rich and wrap clamps expose the same imperative shell so slot
@@ -32,7 +34,7 @@ export interface LineClampProps {
   as?: string;
   text?: string;
   maxLines?: number;
-  maxHeight?: number | string;
+  maxHeight?: ClampLength;
   ellipsis?: string;
   location?: LineClampLocation;
   boundary?: ClampBoundary;
@@ -43,7 +45,7 @@ export interface RichLineClampProps {
   as?: string;
   html: string;
   maxLines?: number;
-  maxHeight?: number | string;
+  maxHeight?: ClampLength;
   ellipsis?: string;
   boundary?: ClampBoundary;
   expanded?: boolean;
@@ -88,6 +90,6 @@ export interface WrapClampProps<T = unknown> {
   items: readonly T[];
   itemKey?: WrapClampItemKey<T>;
   maxLines?: number;
-  maxHeight?: number | string;
+  maxHeight?: ClampLength;
   expanded?: boolean;
 }

--- a/packages/vue-clamp/tests/text.browser.benchmark.ts
+++ b/packages/vue-clamp/tests/text.browser.benchmark.ts
@@ -4,6 +4,7 @@ import { InlineClamp, LineClamp } from "../src/index.ts";
 import * as textHelpers from "../src/text.ts";
 
 import type { App, Ref } from "vue";
+import type { PreparedText, TextClampHint, TextClampResult } from "../src/text.ts";
 
 type BenchmarkMetrics = {
   boundingRectReads: number;
@@ -31,17 +32,6 @@ type ScenarioResult = {
   scenario: string;
   summary: BenchmarkSummary;
 };
-
-type TextClampHint = {
-  boundaryOffsets: readonly number[];
-  kept: number;
-};
-
-type TextClampResult = TextClampHint & {
-  text: string;
-};
-
-type PreparedText = ReturnType<typeof textHelpers.prepareText>;
 
 type TextModule = typeof textHelpers & Record<string, unknown>;
 

--- a/packages/vue-clamp/tests/type-surface.ts
+++ b/packages/vue-clamp/tests/type-surface.ts
@@ -24,7 +24,7 @@ import type {
   MultilineClampShellOptions,
 } from "../src/multiline.ts";
 import type { NativeClampMode, NativeModeInput } from "../src/native.ts";
-import type { LineClampSlots, RichLineClampSlots, WrapClampSlots } from "../src/types.ts";
+import type { LineClampSlots, RichLineClampSlots } from "../src/types.ts";
 import type {
   PreparedText,
   TextClampFitInput,
@@ -48,12 +48,6 @@ import type { TextClampHint as RootTextClampHint } from "../src/index.ts"; // es
 
 // @ts-expect-error Rich helper contracts are source-module API, not package root API.
 import type { RichState as RootRichState } from "../src/index.ts"; // eslint-disable-line no-unused-vars
-
-// @ts-expect-error Slot maps are declaration-building contracts, not package root API.
-import type { WrapClampSlots as RootWrapClampSlots } from "../src/index.ts"; // eslint-disable-line no-unused-vars
-
-// @ts-expect-error Generic WrapClamp component specialization is deferred to a separate API design.
-import type { WrapClampComponent as RootWrapClampComponent } from "../src/index.ts"; // eslint-disable-line no-unused-vars
 
 type Equal<Left, Right> =
   (<Value>() => Value extends Left ? 1 : 2) extends <Value>() => Value extends Right ? 1 : 2
@@ -79,10 +73,6 @@ type _PackageApiTypes = [
   Expect<Equal<WrapClampSlotProps<string>["hiddenItems"], readonly string[]>>,
   Expect<Equal<SlotProps<NonNullable<LineClampSlots["before"]>>, LineClampSlotProps>>,
   Expect<Equal<SlotProps<NonNullable<RichLineClampSlots["after"]>>, RichLineClampSlotProps>>,
-  Expect<Equal<SlotProps<NonNullable<WrapClampSlots<string>["item"]>>["item"], string>>,
-  Expect<
-    Equal<SlotProps<NonNullable<WrapClampSlots<string>["after"]>>["hiddenItems"], readonly string[]>
-  >,
   Expect<Equal<LineClampSlotProps["toggle"], () => void>>,
   Expect<Equal<RichLineClampSlotProps["expanded"], boolean>>,
   Expect<Equal<LineClampExposed["clamped"], boolean>>,

--- a/packages/vue-clamp/tests/type-surface.ts
+++ b/packages/vue-clamp/tests/type-surface.ts
@@ -1,0 +1,121 @@
+import type { Ref } from "vue";
+import type {
+  ClampBoundary,
+  ClampLength,
+  InlineClampParts,
+  InlineClampProps,
+  InlineClampSplit,
+  LineClampExposed,
+  LineClampLocation,
+  LineClampProps,
+  LineClampSlotProps,
+  RichLineClampExposed,
+  RichLineClampProps,
+  RichLineClampSlotProps,
+  WrapClampExposed,
+  WrapClampItemKey,
+  WrapClampItemSlotProps,
+  WrapClampProps,
+  WrapClampSlotProps,
+} from "../src/index.ts";
+import type {
+  MultilineClampFrameRefs,
+  MultilineClampShell,
+  MultilineClampShellOptions,
+} from "../src/multiline.ts";
+import type { NativeClampMode, NativeModeInput } from "../src/native.ts";
+import type { LineClampSlots, RichLineClampSlots, WrapClampSlots } from "../src/types.ts";
+import type {
+  PreparedText,
+  TextClampFitInput,
+  TextClampHint,
+  TextClampLayoutInput,
+  TextClampResult,
+  TextClampSpacing,
+} from "../src/text.ts";
+import type {
+  PreparedRich,
+  PreparedRichNode,
+  RichBoundaryPoint,
+  RichClampOptions,
+  RichClampProbe,
+  RichClampResult,
+  RichState,
+} from "../src/rich.ts";
+
+// @ts-expect-error Text helper contracts are source-module API, not package root API.
+import type { TextClampHint as RootTextClampHint } from "../src/index.ts"; // eslint-disable-line no-unused-vars
+
+// @ts-expect-error Rich helper contracts are source-module API, not package root API.
+import type { RichState as RootRichState } from "../src/index.ts"; // eslint-disable-line no-unused-vars
+
+// @ts-expect-error Slot maps are declaration-building contracts, not package root API.
+import type { WrapClampSlots as RootWrapClampSlots } from "../src/index.ts"; // eslint-disable-line no-unused-vars
+
+// @ts-expect-error Generic WrapClamp component specialization is deferred to a separate API design.
+import type { WrapClampComponent as RootWrapClampComponent } from "../src/index.ts"; // eslint-disable-line no-unused-vars
+
+type Equal<Left, Right> =
+  (<Value>() => Value extends Left ? 1 : 2) extends <Value>() => Value extends Right ? 1 : 2
+    ? true
+    : false;
+
+type Expect<Value extends true> = Value;
+type SlotProps<Slot> = Slot extends (props: infer Props) => unknown ? Props : never;
+
+type _PackageApiTypes = [
+  Expect<Equal<ClampBoundary, "grapheme" | "word">>,
+  Expect<Equal<ClampLength, number | string>>,
+  Expect<Equal<LineClampLocation, "start" | "middle" | "end" | number>>,
+  Expect<Equal<LineClampProps["maxHeight"], ClampLength | undefined>>,
+  Expect<Equal<RichLineClampProps["maxHeight"], ClampLength | undefined>>,
+  Expect<Equal<WrapClampProps["maxHeight"], ClampLength | undefined>>,
+  Expect<Equal<InlineClampProps["split"], InlineClampSplit | undefined>>,
+  Expect<Equal<InlineClampSplit, (text: string) => InlineClampParts>>,
+  Expect<
+    Equal<WrapClampItemKey<string>, string | ((item: string, index: number) => string | number)>
+  >,
+  Expect<Equal<WrapClampItemSlotProps<string>["item"], string>>,
+  Expect<Equal<WrapClampSlotProps<string>["hiddenItems"], readonly string[]>>,
+  Expect<Equal<SlotProps<NonNullable<LineClampSlots["before"]>>, LineClampSlotProps>>,
+  Expect<Equal<SlotProps<NonNullable<RichLineClampSlots["after"]>>, RichLineClampSlotProps>>,
+  Expect<Equal<SlotProps<NonNullable<WrapClampSlots<string>["item"]>>["item"], string>>,
+  Expect<
+    Equal<SlotProps<NonNullable<WrapClampSlots<string>["after"]>>["hiddenItems"], readonly string[]>
+  >,
+  Expect<Equal<LineClampSlotProps["toggle"], () => void>>,
+  Expect<Equal<RichLineClampSlotProps["expanded"], boolean>>,
+  Expect<Equal<LineClampExposed["clamped"], boolean>>,
+  Expect<Equal<RichLineClampExposed["expanded"], boolean>>,
+  Expect<Equal<WrapClampExposed["toggle"], () => void>>,
+];
+
+type _TextHelperContracts = [
+  Expect<Equal<TextClampSpacing, "trim" | "preserve-outer">>,
+  Expect<Equal<PreparedText["boundaryOffsets"], readonly number[]>>,
+  Expect<Equal<TextClampHint["boundaryOffsets"], readonly number[]>>,
+  Expect<Equal<TextClampResult["text"], string>>,
+  Expect<Equal<TextClampFitInput["prepared"], PreparedText>>,
+  Expect<Equal<TextClampLayoutInput["maxHeight"], ClampLength | undefined>>,
+];
+
+type _RichHelperContracts = [
+  Expect<Equal<RichBoundaryPoint["path"], readonly number[]>>,
+  Expect<Equal<PreparedRich["nodes"], readonly PreparedRichNode[]>>,
+  Expect<Equal<Extract<RichState, { kind: "clamped" }>["point"], RichBoundaryPoint>>,
+  Expect<Equal<RichClampProbe["body"], HTMLElement>>,
+  Expect<Equal<RichClampOptions["prepared"], PreparedRich>>,
+  Expect<Equal<RichClampResult["state"], RichState | null>>,
+];
+
+type _NativeHelperContracts = [
+  Expect<Equal<NativeClampMode, "single-line" | "multi-line">>,
+  Expect<Equal<NativeModeInput["maxHeight"], ClampLength | undefined>>,
+  Expect<Equal<NativeModeInput["boundary"], ClampBoundary>>,
+];
+
+type _MultilineHelperContracts = [
+  Expect<Equal<MultilineClampFrameRefs["rootRef"], Ref<HTMLElement | null>>>,
+  Expect<Equal<MultilineClampShellOptions["recompute"], (expanded: Ref<boolean>) => Promise<void>>>,
+  Expect<Equal<MultilineClampShell["requestRecompute"], () => void>>,
+];

--- a/packages/vue-clamp/tests/wrap.browser.benchmark.ts
+++ b/packages/vue-clamp/tests/wrap.browser.benchmark.ts
@@ -42,6 +42,17 @@ type MountedVariant = {
   itemSlotCalls: () => number;
   mountedBenchmark: MountedBenchmark;
 };
+type NoAffixGrowProfile = {
+  hostWidth: number;
+  itemCount: number;
+  itemWidth: number;
+  rowCount: number;
+  widths: readonly number[];
+};
+type MaxHeightProfileOptions = {
+  beforeWidth?: number;
+  maxLines?: number;
+};
 type ScenarioObservation = {
   clamps: ClampSnapshot[];
   signature: string;
@@ -72,6 +83,36 @@ const singleLineWidths = [
   140, 160, 180, 200, 220, 240, 260, 280, 300, 280, 260, 240, 220, 200, 180, 160, 140,
 ];
 const tableWidths = [180, 220, 260, 300, 340, 300, 260, 220, 180];
+const tableWidthBursts = [
+  [220, 260, 300, 340],
+  [300, 260, 220, 180],
+  [220, 260, 300, 340],
+  [300, 260, 220, 180],
+] as const;
+const noAffixJumpGrowWidths = [340, 180, 340, 180, 340, 180, 340];
+const noAffixShrinkWidths = [340, 220, 180, 150, 120];
+const noAffixHiddenGrowWidths = [120, 520, 120, 520, 120, 520];
+const noAffixLargeNWidths = [120, 520, 120, 520];
+const noAffixNarrowItemGrowWidths = [120, 520, 120, 520];
+const noAffixWideItemGrowWidths = [160, 520, 160, 520];
+const noAffixWideContainerGrowWidths = [120, 760, 120, 760];
+const noAffixTinyItemWideGrowWidths = [120, 960, 120, 960];
+const noAffixMixedItemGrowWidths = [120, 680, 120, 680];
+const noAffixHeavyItemGrowWidths = [120, 520, 120, 520, 120, 520];
+const beforeAffixGrowWidths = [120, 520, 120, 520];
+const beforeAffixShrinkWidths = [520, 360, 240, 160, 120];
+const dynamicBeforeGrowWidths = [120, 520, 120, 520];
+const dynamicBeforeShrinkWidths = [520, 360, 240, 160, 120];
+const staticAfterGrowWidths = [120, 520, 120, 520];
+const staticAfterShrinkWidths = [520, 360, 240, 160, 120];
+const staticBeforeDynamicAfterGrowWidths = [120, 520, 120, 520];
+const afterAffixShrinkWidths = [520, 360, 240, 160, 120];
+const maxHeightGrowWidths = [120, 520, 120, 520];
+const maxHeightShrinkWidths = [520, 360, 240, 160, 120];
+const beforeMaxHeightGrowWidths = [120, 520, 120, 520];
+const beforeMaxHeightShrinkWidths = [520, 360, 240, 160, 120];
+const mixedLimitGrowWidths = [120, 520, 120, 520];
+const mixedLimitShrinkWidths = [520, 360, 240, 160, 120];
 const benchmarkWarmupRuns = 1;
 const benchmarkMeasuredRuns = 5;
 
@@ -410,6 +451,1061 @@ function mountTableVariant(component: Component): MountedVariant {
   };
 }
 
+function mountNoAffixJumpGrowVariant(component: Component): MountedVariant {
+  const width = ref(noAffixJumpGrowWidths[0] ?? 340);
+  const container = document.createElement("div");
+  document.body.append(container);
+
+  let itemSlotCalls = 0;
+  let beforeSlotCalls = 0;
+  let afterSlotCalls = 0;
+  const rows = buildTableRows();
+
+  const Host = defineComponent({
+    setup() {
+      return () =>
+        h(
+          "div",
+          {
+            style: hostStyle(360),
+          },
+          h("table", { style: "table-layout:auto;width:100%;border-collapse:collapse;" }, [
+            h(
+              "tbody",
+              rows.map((row) =>
+                h("tr", { key: row.id }, [
+                  h("td", { style: "padding:4px 8px;white-space:nowrap;" }, row.id),
+                  h("td", { style: "padding:4px 8px;white-space:nowrap;" }, "Owner"),
+                  h(
+                    "td",
+                    { style: "padding:4px 8px;" },
+                    h(
+                      component,
+                      {
+                        items: row.labels,
+                        maxLines: 2,
+                        style: `width:${width.value}px;max-width:100%;`,
+                      },
+                      {
+                        item: ({ item }: { item: string }) => {
+                          itemSlotCalls += 1;
+                          return h("span", { style: fixedBadgeStyle(68) }, item);
+                        },
+                      },
+                    ),
+                  ),
+                ]),
+              ),
+            ),
+          ]),
+        );
+    },
+  });
+
+  const app = createApp(Host);
+  app.mount(container);
+
+  const mountedBenchmark = {
+    app,
+    container,
+    width,
+  };
+  mounted.add(mountedBenchmark);
+
+  return {
+    afterSlotCalls: () => afterSlotCalls,
+    beforeSlotCalls: () => beforeSlotCalls,
+    itemSlotCalls: () => itemSlotCalls,
+    mountedBenchmark,
+  };
+}
+
+function mountNoAffixHiddenGrowVariant(component: Component): MountedVariant {
+  const width = ref(noAffixHiddenGrowWidths[0] ?? 120);
+  const container = document.createElement("div");
+  document.body.append(container);
+
+  let itemSlotCalls = 0;
+  let beforeSlotCalls = 0;
+  let afterSlotCalls = 0;
+  const rows = Array.from({ length: 100 }, (_, rowIndex) => ({
+    id: `R-${rowIndex + 1}`,
+    labels: Array.from({ length: 24 }, (_, itemIndex) => `I${itemIndex + 1}`),
+  }));
+
+  const Host = defineComponent({
+    setup() {
+      return () =>
+        h(
+          "div",
+          {
+            style: hostStyle(640),
+          },
+          h("table", { style: "table-layout:auto;width:100%;border-collapse:collapse;" }, [
+            h(
+              "tbody",
+              rows.map((row) =>
+                h("tr", { key: row.id }, [
+                  h("td", { style: "padding:4px 8px;white-space:nowrap;" }, row.id),
+                  h(
+                    "td",
+                    { style: "padding:4px 8px;" },
+                    h(
+                      component,
+                      {
+                        items: row.labels,
+                        maxLines: 2,
+                        style: `width:${width.value}px;max-width:100%;`,
+                      },
+                      {
+                        item: ({ item }: { item: string }) => {
+                          itemSlotCalls += 1;
+                          return h("span", { style: fixedBadgeStyle(40) }, item);
+                        },
+                      },
+                    ),
+                  ),
+                ]),
+              ),
+            ),
+          ]),
+        );
+    },
+  });
+
+  const app = createApp(Host);
+  app.mount(container);
+
+  const mountedBenchmark = {
+    app,
+    container,
+    width,
+  };
+  mounted.add(mountedBenchmark);
+
+  return {
+    afterSlotCalls: () => afterSlotCalls,
+    beforeSlotCalls: () => beforeSlotCalls,
+    itemSlotCalls: () => itemSlotCalls,
+    mountedBenchmark,
+  };
+}
+
+function mountNoAffixLargeNVariant(component: Component): MountedVariant {
+  const width = ref(noAffixLargeNWidths[0] ?? 120);
+  const container = document.createElement("div");
+  document.body.append(container);
+
+  let itemSlotCalls = 0;
+  let beforeSlotCalls = 0;
+  let afterSlotCalls = 0;
+  const rows = Array.from({ length: 40 }, (_, rowIndex) => ({
+    id: `R-${rowIndex + 1}`,
+    labels: Array.from({ length: 200 }, (_, itemIndex) => `I${itemIndex + 1}`),
+  }));
+
+  const Host = defineComponent({
+    setup() {
+      return () =>
+        h(
+          "div",
+          {
+            style: hostStyle(640),
+          },
+          h("table", { style: "table-layout:auto;width:100%;border-collapse:collapse;" }, [
+            h(
+              "tbody",
+              rows.map((row) =>
+                h("tr", { key: row.id }, [
+                  h("td", { style: "padding:4px 8px;white-space:nowrap;" }, row.id),
+                  h(
+                    "td",
+                    { style: "padding:4px 8px;" },
+                    h(
+                      component,
+                      {
+                        items: row.labels,
+                        maxLines: 2,
+                        style: `width:${width.value}px;max-width:100%;`,
+                      },
+                      {
+                        item: ({ item }: { item: string }) => {
+                          itemSlotCalls += 1;
+                          return h("span", { style: fixedBadgeStyle(40) }, item);
+                        },
+                      },
+                    ),
+                  ),
+                ]),
+              ),
+            ),
+          ]),
+        );
+    },
+  });
+
+  const app = createApp(Host);
+  app.mount(container);
+
+  const mountedBenchmark = {
+    app,
+    container,
+    width,
+  };
+  mounted.add(mountedBenchmark);
+
+  return {
+    afterSlotCalls: () => afterSlotCalls,
+    beforeSlotCalls: () => beforeSlotCalls,
+    itemSlotCalls: () => itemSlotCalls,
+    mountedBenchmark,
+  };
+}
+
+function mountNoAffixGrowProfileVariant(
+  component: Component,
+  profile: NoAffixGrowProfile,
+): MountedVariant {
+  const width = ref(profile.widths[0] ?? 120);
+  const container = document.createElement("div");
+  document.body.append(container);
+
+  let itemSlotCalls = 0;
+  let beforeSlotCalls = 0;
+  let afterSlotCalls = 0;
+  const rows = Array.from({ length: profile.rowCount }, (_, rowIndex) => ({
+    id: `R-${rowIndex + 1}`,
+    labels: Array.from({ length: profile.itemCount }, (_, itemIndex) => `I${itemIndex + 1}`),
+  }));
+
+  const Host = defineComponent({
+    setup() {
+      return () =>
+        h(
+          "div",
+          {
+            style: hostStyle(profile.hostWidth),
+          },
+          h("table", { style: "table-layout:auto;width:100%;border-collapse:collapse;" }, [
+            h(
+              "tbody",
+              rows.map((row) =>
+                h("tr", { key: row.id }, [
+                  h("td", { style: "padding:4px 8px;white-space:nowrap;" }, row.id),
+                  h(
+                    "td",
+                    { style: "padding:4px 8px;" },
+                    h(
+                      component,
+                      {
+                        items: row.labels,
+                        maxLines: 2,
+                        style: `width:${width.value}px;max-width:100%;`,
+                      },
+                      {
+                        item: ({ item }: { item: string }) => {
+                          itemSlotCalls += 1;
+                          return h("span", { style: fixedBadgeStyle(profile.itemWidth) }, item);
+                        },
+                      },
+                    ),
+                  ),
+                ]),
+              ),
+            ),
+          ]),
+        );
+    },
+  });
+
+  const app = createApp(Host);
+  app.mount(container);
+
+  const mountedBenchmark = {
+    app,
+    container,
+    width,
+  };
+  mounted.add(mountedBenchmark);
+
+  return {
+    afterSlotCalls: () => afterSlotCalls,
+    beforeSlotCalls: () => beforeSlotCalls,
+    itemSlotCalls: () => itemSlotCalls,
+    mountedBenchmark,
+  };
+}
+
+function mountNoAffixNarrowItemGrowVariant(component: Component): MountedVariant {
+  return mountNoAffixGrowProfileVariant(component, {
+    hostWidth: 640,
+    itemCount: 48,
+    itemWidth: 28,
+    rowCount: 60,
+    widths: noAffixNarrowItemGrowWidths,
+  });
+}
+
+function mountNoAffixWideItemGrowVariant(component: Component): MountedVariant {
+  return mountNoAffixGrowProfileVariant(component, {
+    hostWidth: 640,
+    itemCount: 24,
+    itemWidth: 72,
+    rowCount: 60,
+    widths: noAffixWideItemGrowWidths,
+  });
+}
+
+function mountNoAffixWideContainerGrowVariant(component: Component): MountedVariant {
+  return mountNoAffixGrowProfileVariant(component, {
+    hostWidth: 880,
+    itemCount: 64,
+    itemWidth: 40,
+    rowCount: 60,
+    widths: noAffixWideContainerGrowWidths,
+  });
+}
+
+function mountNoAffixTinyItemWideGrowVariant(component: Component): MountedVariant {
+  return mountNoAffixGrowProfileVariant(component, {
+    hostWidth: 1040,
+    itemCount: 120,
+    itemWidth: 16,
+    rowCount: 40,
+    widths: noAffixTinyItemWideGrowWidths,
+  });
+}
+
+function mountNoAffixMixedItemGrowVariant(component: Component): MountedVariant {
+  const width = ref(noAffixMixedItemGrowWidths[0] ?? 120);
+  const container = document.createElement("div");
+  document.body.append(container);
+
+  let itemSlotCalls = 0;
+  let beforeSlotCalls = 0;
+  let afterSlotCalls = 0;
+  const itemWidths = [24, 64, 36, 96, 48, 120, 28, 72];
+  const rows = Array.from({ length: 60 }, (_, rowIndex) => ({
+    id: `R-${rowIndex + 1}`,
+    labels: Array.from({ length: 64 }, (_, itemIndex) => `I${itemIndex + 1}`),
+  }));
+
+  const Host = defineComponent({
+    setup() {
+      return () =>
+        h(
+          "div",
+          {
+            style: hostStyle(760),
+          },
+          h("table", { style: "table-layout:auto;width:100%;border-collapse:collapse;" }, [
+            h(
+              "tbody",
+              rows.map((row) =>
+                h("tr", { key: row.id }, [
+                  h("td", { style: "padding:4px 8px;white-space:nowrap;" }, row.id),
+                  h(
+                    "td",
+                    { style: "padding:4px 8px;" },
+                    h(
+                      component,
+                      {
+                        items: row.labels,
+                        maxLines: 2,
+                        style: `width:${width.value}px;max-width:100%;`,
+                      },
+                      {
+                        item: ({ index, item }: { index: number; item: string }) => {
+                          itemSlotCalls += 1;
+                          return h(
+                            "span",
+                            { style: fixedBadgeStyle(itemWidths[index % itemWidths.length] ?? 40) },
+                            item,
+                          );
+                        },
+                      },
+                    ),
+                  ),
+                ]),
+              ),
+            ),
+          ]),
+        );
+    },
+  });
+
+  const app = createApp(Host);
+  app.mount(container);
+
+  const mountedBenchmark = {
+    app,
+    container,
+    width,
+  };
+  mounted.add(mountedBenchmark);
+
+  return {
+    afterSlotCalls: () => afterSlotCalls,
+    beforeSlotCalls: () => beforeSlotCalls,
+    itemSlotCalls: () => itemSlotCalls,
+    mountedBenchmark,
+  };
+}
+
+function mountNoAffixHeavyItemGrowVariant(component: Component): MountedVariant {
+  const width = ref(noAffixHeavyItemGrowWidths[0] ?? 120);
+  const container = document.createElement("div");
+  document.body.append(container);
+
+  let itemSlotCalls = 0;
+  let beforeSlotCalls = 0;
+  let afterSlotCalls = 0;
+  const rows = Array.from({ length: 100 }, (_, rowIndex) => ({
+    id: `R-${rowIndex + 1}`,
+    labels: Array.from({ length: 24 }, (_, itemIndex) => `I${itemIndex + 1}`),
+  }));
+
+  function renderWork(seed: string): number {
+    let hash = 0;
+    for (let index = 0; index < 600; index += 1) {
+      hash = (hash * 33 + seed.charCodeAt(index % seed.length)) % 100_000;
+    }
+
+    return hash;
+  }
+
+  const Host = defineComponent({
+    setup() {
+      return () =>
+        h(
+          "div",
+          {
+            style: hostStyle(640),
+          },
+          h("table", { style: "table-layout:auto;width:100%;border-collapse:collapse;" }, [
+            h(
+              "tbody",
+              rows.map((row) =>
+                h("tr", { key: row.id }, [
+                  h("td", { style: "padding:4px 8px;white-space:nowrap;" }, row.id),
+                  h(
+                    "td",
+                    { style: "padding:4px 8px;" },
+                    h(
+                      component,
+                      {
+                        items: row.labels,
+                        maxLines: 2,
+                        style: `width:${width.value}px;max-width:100%;`,
+                      },
+                      {
+                        item: ({ item }: { item: string }) => {
+                          itemSlotCalls += 1;
+                          return h(
+                            "span",
+                            {
+                              "data-render-work": renderWork(item),
+                              style: fixedBadgeStyle(40),
+                            },
+                            item,
+                          );
+                        },
+                      },
+                    ),
+                  ),
+                ]),
+              ),
+            ),
+          ]),
+        );
+    },
+  });
+
+  const app = createApp(Host);
+  app.mount(container);
+
+  const mountedBenchmark = {
+    app,
+    container,
+    width,
+  };
+  mounted.add(mountedBenchmark);
+
+  return {
+    afterSlotCalls: () => afterSlotCalls,
+    beforeSlotCalls: () => beforeSlotCalls,
+    itemSlotCalls: () => itemSlotCalls,
+    mountedBenchmark,
+  };
+}
+
+function mountBeforeAffixGrowVariant(component: Component): MountedVariant {
+  return mountBeforeAffixProfileVariant(component, beforeAffixGrowWidths);
+}
+
+function mountBeforeAffixShrinkVariant(component: Component): MountedVariant {
+  return mountBeforeAffixProfileVariant(component, beforeAffixShrinkWidths);
+}
+
+function mountDynamicBeforeGrowVariant(component: Component): MountedVariant {
+  return mountDynamicBeforeProfileVariant(component, dynamicBeforeGrowWidths);
+}
+
+function mountDynamicBeforeShrinkVariant(component: Component): MountedVariant {
+  return mountDynamicBeforeProfileVariant(component, dynamicBeforeShrinkWidths);
+}
+
+function mountDynamicBeforeProfileVariant(
+  component: Component,
+  widths: readonly number[],
+): MountedVariant {
+  const width = ref(widths[0] ?? 120);
+  const container = document.createElement("div");
+  document.body.append(container);
+
+  let itemSlotCalls = 0;
+  let beforeSlotCalls = 0;
+  let afterSlotCalls = 0;
+  const rows = Array.from({ length: 100 }, (_, rowIndex) => ({
+    id: `R-${rowIndex + 1}`,
+    labels: Array.from({ length: 24 }, (_, itemIndex) => `I${itemIndex + 1}`),
+  }));
+
+  const Host = defineComponent({
+    setup() {
+      return () =>
+        h(
+          "div",
+          {
+            style: hostStyle(640),
+          },
+          h("table", { style: "table-layout:auto;width:100%;border-collapse:collapse;" }, [
+            h(
+              "tbody",
+              rows.map((row) =>
+                h("tr", { key: row.id }, [
+                  h("td", { style: "padding:4px 8px;white-space:nowrap;" }, row.id),
+                  h(
+                    "td",
+                    { style: "padding:4px 8px;" },
+                    h(
+                      component,
+                      {
+                        items: row.labels,
+                        maxLines: 2,
+                        style: `width:${width.value}px;max-width:100%;`,
+                      },
+                      {
+                        before: ({ hiddenItems }: { hiddenItems: readonly string[] }) => {
+                          beforeSlotCalls += 1;
+                          return h(
+                            "span",
+                            { style: fixedBadgeStyle(hiddenItems.length >= 10 ? 160 : 40) },
+                            "Lead",
+                          );
+                        },
+                        item: ({ item }: { item: string }) => {
+                          itemSlotCalls += 1;
+                          return h("span", { style: fixedBadgeStyle(40) }, item);
+                        },
+                      },
+                    ),
+                  ),
+                ]),
+              ),
+            ),
+          ]),
+        );
+    },
+  });
+
+  const app = createApp(Host);
+  app.mount(container);
+
+  const mountedBenchmark = {
+    app,
+    container,
+    width,
+  };
+  mounted.add(mountedBenchmark);
+
+  return {
+    afterSlotCalls: () => afterSlotCalls,
+    beforeSlotCalls: () => beforeSlotCalls,
+    itemSlotCalls: () => itemSlotCalls,
+    mountedBenchmark,
+  };
+}
+
+function mountAfterAffixShrinkVariant(component: Component): MountedVariant {
+  const width = ref(afterAffixShrinkWidths[0] ?? 520);
+  const container = document.createElement("div");
+  document.body.append(container);
+
+  let itemSlotCalls = 0;
+  let beforeSlotCalls = 0;
+  let afterSlotCalls = 0;
+  const rows = Array.from({ length: 100 }, (_, rowIndex) => ({
+    id: `R-${rowIndex + 1}`,
+    labels: Array.from({ length: 24 }, (_, itemIndex) => `I${itemIndex + 1}`),
+  }));
+
+  const Host = defineComponent({
+    setup() {
+      return () =>
+        h(
+          "div",
+          {
+            style: hostStyle(640),
+          },
+          h("table", { style: "table-layout:auto;width:100%;border-collapse:collapse;" }, [
+            h(
+              "tbody",
+              rows.map((row) =>
+                h("tr", { key: row.id }, [
+                  h("td", { style: "padding:4px 8px;white-space:nowrap;" }, row.id),
+                  h(
+                    "td",
+                    { style: "padding:4px 8px;" },
+                    h(
+                      component,
+                      {
+                        items: row.labels,
+                        maxLines: 2,
+                        style: `width:${width.value}px;max-width:100%;`,
+                      },
+                      {
+                        item: ({ item }: { item: string }) => {
+                          itemSlotCalls += 1;
+                          return h("span", { style: fixedBadgeStyle(40) }, item);
+                        },
+                        after: ({
+                          clamped,
+                          hiddenItems,
+                        }: {
+                          clamped: boolean;
+                          hiddenItems: readonly string[];
+                        }) => {
+                          afterSlotCalls += 1;
+                          return clamped
+                            ? h(
+                                "span",
+                                {
+                                  style: fixedBadgeStyle(hiddenItems.length >= 10 ? 68 : 32),
+                                },
+                                `+${hiddenItems.length}`,
+                              )
+                            : null;
+                        },
+                      },
+                    ),
+                  ),
+                ]),
+              ),
+            ),
+          ]),
+        );
+    },
+  });
+
+  const app = createApp(Host);
+  app.mount(container);
+
+  const mountedBenchmark = {
+    app,
+    container,
+    width,
+  };
+  mounted.add(mountedBenchmark);
+
+  return {
+    afterSlotCalls: () => afterSlotCalls,
+    beforeSlotCalls: () => beforeSlotCalls,
+    itemSlotCalls: () => itemSlotCalls,
+    mountedBenchmark,
+  };
+}
+
+function mountStaticAfterGrowVariant(component: Component): MountedVariant {
+  return mountStaticAfterProfileVariant(component, staticAfterGrowWidths);
+}
+
+function mountStaticAfterShrinkVariant(component: Component): MountedVariant {
+  return mountStaticAfterProfileVariant(component, staticAfterShrinkWidths);
+}
+
+function mountStaticAfterProfileVariant(
+  component: Component,
+  widths: readonly number[],
+): MountedVariant {
+  const width = ref(widths[0] ?? 120);
+  const container = document.createElement("div");
+  document.body.append(container);
+
+  let itemSlotCalls = 0;
+  let beforeSlotCalls = 0;
+  let afterSlotCalls = 0;
+  const rows = Array.from({ length: 100 }, (_, rowIndex) => ({
+    id: `R-${rowIndex + 1}`,
+    labels: Array.from({ length: 24 }, (_, itemIndex) => `I${itemIndex + 1}`),
+  }));
+
+  const Host = defineComponent({
+    setup() {
+      return () =>
+        h(
+          "div",
+          {
+            style: hostStyle(640),
+          },
+          h("table", { style: "table-layout:auto;width:100%;border-collapse:collapse;" }, [
+            h(
+              "tbody",
+              rows.map((row) =>
+                h("tr", { key: row.id }, [
+                  h("td", { style: "padding:4px 8px;white-space:nowrap;" }, row.id),
+                  h(
+                    "td",
+                    { style: "padding:4px 8px;" },
+                    h(
+                      component,
+                      {
+                        items: row.labels,
+                        maxLines: 2,
+                        style: `width:${width.value}px;max-width:100%;`,
+                      },
+                      {
+                        item: ({ item }: { item: string }) => {
+                          itemSlotCalls += 1;
+                          return h("span", { style: fixedBadgeStyle(40) }, item);
+                        },
+                        after: ({ clamped }: { clamped: boolean }) => {
+                          afterSlotCalls += 1;
+                          return clamped ? h("span", { style: fixedBadgeStyle(52) }, "More") : null;
+                        },
+                      },
+                    ),
+                  ),
+                ]),
+              ),
+            ),
+          ]),
+        );
+    },
+  });
+
+  const app = createApp(Host);
+  app.mount(container);
+
+  const mountedBenchmark = {
+    app,
+    container,
+    width,
+  };
+  mounted.add(mountedBenchmark);
+
+  return {
+    afterSlotCalls: () => afterSlotCalls,
+    beforeSlotCalls: () => beforeSlotCalls,
+    itemSlotCalls: () => itemSlotCalls,
+    mountedBenchmark,
+  };
+}
+
+function mountStaticBeforeDynamicAfterGrowVariant(component: Component): MountedVariant {
+  const width = ref(staticBeforeDynamicAfterGrowWidths[0] ?? 120);
+  const container = document.createElement("div");
+  document.body.append(container);
+
+  let itemSlotCalls = 0;
+  let beforeSlotCalls = 0;
+  let afterSlotCalls = 0;
+  const rows = Array.from({ length: 100 }, (_, rowIndex) => ({
+    id: `R-${rowIndex + 1}`,
+    labels: Array.from({ length: 24 }, (_, itemIndex) => `I${itemIndex + 1}`),
+  }));
+
+  const Host = defineComponent({
+    setup() {
+      return () =>
+        h(
+          "div",
+          {
+            style: hostStyle(640),
+          },
+          h("table", { style: "table-layout:auto;width:100%;border-collapse:collapse;" }, [
+            h(
+              "tbody",
+              rows.map((row) =>
+                h("tr", { key: row.id }, [
+                  h("td", { style: "padding:4px 8px;white-space:nowrap;" }, row.id),
+                  h(
+                    "td",
+                    { style: "padding:4px 8px;" },
+                    h(
+                      component,
+                      {
+                        items: row.labels,
+                        maxLines: 2,
+                        style: `width:${width.value}px;max-width:100%;`,
+                      },
+                      {
+                        before: () => {
+                          beforeSlotCalls += 1;
+                          return h("span", { style: fixedBadgeStyle(72) }, "Lead");
+                        },
+                        item: ({ item }: { item: string }) => {
+                          itemSlotCalls += 1;
+                          return h("span", { style: fixedBadgeStyle(40) }, item);
+                        },
+                        after: ({
+                          clamped,
+                          hiddenItems,
+                        }: {
+                          clamped: boolean;
+                          hiddenItems: readonly string[];
+                        }) => {
+                          afterSlotCalls += 1;
+                          const hiddenCount = hiddenItems.length;
+                          return clamped
+                            ? h(
+                                "span",
+                                {
+                                  style: fixedBadgeStyle(hiddenCount >= 10 ? 68 : 32),
+                                },
+                                `+${hiddenCount}`,
+                              )
+                            : null;
+                        },
+                      },
+                    ),
+                  ),
+                ]),
+              ),
+            ),
+          ]),
+        );
+    },
+  });
+
+  const app = createApp(Host);
+  app.mount(container);
+
+  const mountedBenchmark = {
+    app,
+    container,
+    width,
+  };
+  mounted.add(mountedBenchmark);
+
+  return {
+    afterSlotCalls: () => afterSlotCalls,
+    beforeSlotCalls: () => beforeSlotCalls,
+    itemSlotCalls: () => itemSlotCalls,
+    mountedBenchmark,
+  };
+}
+
+function mountMaxHeightGrowVariant(component: Component): MountedVariant {
+  return mountMaxHeightProfileVariant(component, maxHeightGrowWidths);
+}
+
+function mountMaxHeightShrinkVariant(component: Component): MountedVariant {
+  return mountMaxHeightProfileVariant(component, maxHeightShrinkWidths);
+}
+
+function mountBeforeMaxHeightGrowVariant(component: Component): MountedVariant {
+  return mountMaxHeightProfileVariant(component, beforeMaxHeightGrowWidths, {
+    beforeWidth: 72,
+  });
+}
+
+function mountBeforeMaxHeightShrinkVariant(component: Component): MountedVariant {
+  return mountMaxHeightProfileVariant(component, beforeMaxHeightShrinkWidths, {
+    beforeWidth: 72,
+  });
+}
+
+function mountMixedLimitGrowVariant(component: Component): MountedVariant {
+  return mountMaxHeightProfileVariant(component, mixedLimitGrowWidths, {
+    maxLines: 3,
+  });
+}
+
+function mountMixedLimitShrinkVariant(component: Component): MountedVariant {
+  return mountMaxHeightProfileVariant(component, mixedLimitShrinkWidths, {
+    maxLines: 3,
+  });
+}
+
+function mountMaxHeightProfileVariant(
+  component: Component,
+  widths: readonly number[],
+  options: MaxHeightProfileOptions = {},
+): MountedVariant {
+  const width = ref(widths[0] ?? 120);
+  const container = document.createElement("div");
+  document.body.append(container);
+
+  let itemSlotCalls = 0;
+  let beforeSlotCalls = 0;
+  let afterSlotCalls = 0;
+  const rows = Array.from({ length: 100 }, (_, rowIndex) => ({
+    id: `R-${rowIndex + 1}`,
+    labels: Array.from({ length: 24 }, (_, itemIndex) => `I${itemIndex + 1}`),
+  }));
+
+  const Host = defineComponent({
+    setup() {
+      const item = ({ item }: { item: string }) => {
+        itemSlotCalls += 1;
+        return h("span", { style: fixedBadgeStyle(40) }, item);
+      };
+
+      return () =>
+        h(
+          "div",
+          {
+            style: hostStyle(640),
+          },
+          h("table", { style: "table-layout:auto;width:100%;border-collapse:collapse;" }, [
+            h(
+              "tbody",
+              rows.map((row) =>
+                h("tr", { key: row.id }, [
+                  h("td", { style: "padding:4px 8px;white-space:nowrap;" }, row.id),
+                  h(
+                    "td",
+                    { style: "padding:4px 8px;" },
+                    h(
+                      component,
+                      {
+                        items: row.labels,
+                        maxHeight: "60px",
+                        maxLines: options.maxLines,
+                        style: `width:${width.value}px;max-width:100%;`,
+                      },
+                      options.beforeWidth === undefined
+                        ? {
+                            item,
+                          }
+                        : {
+                            before: () => {
+                              beforeSlotCalls += 1;
+                              return h(
+                                "span",
+                                { style: fixedBadgeStyle(options.beforeWidth ?? 0) },
+                                "Lead",
+                              );
+                            },
+                            item,
+                          },
+                    ),
+                  ),
+                ]),
+              ),
+            ),
+          ]),
+        );
+    },
+  });
+
+  const app = createApp(Host);
+  app.mount(container);
+
+  const mountedBenchmark = {
+    app,
+    container,
+    width,
+  };
+  mounted.add(mountedBenchmark);
+
+  return {
+    afterSlotCalls: () => afterSlotCalls,
+    beforeSlotCalls: () => beforeSlotCalls,
+    itemSlotCalls: () => itemSlotCalls,
+    mountedBenchmark,
+  };
+}
+
+function mountBeforeAffixProfileVariant(
+  component: Component,
+  widths: readonly number[],
+): MountedVariant {
+  const width = ref(widths[0] ?? 120);
+  const container = document.createElement("div");
+  document.body.append(container);
+
+  let itemSlotCalls = 0;
+  let beforeSlotCalls = 0;
+  let afterSlotCalls = 0;
+  const rows = Array.from({ length: 100 }, (_, rowIndex) => ({
+    id: `R-${rowIndex + 1}`,
+    labels: Array.from({ length: 24 }, (_, itemIndex) => `I${itemIndex + 1}`),
+  }));
+
+  const Host = defineComponent({
+    setup() {
+      return () =>
+        h(
+          "div",
+          {
+            style: hostStyle(640),
+          },
+          h("table", { style: "table-layout:auto;width:100%;border-collapse:collapse;" }, [
+            h(
+              "tbody",
+              rows.map((row) =>
+                h("tr", { key: row.id }, [
+                  h("td", { style: "padding:4px 8px;white-space:nowrap;" }, row.id),
+                  h(
+                    "td",
+                    { style: "padding:4px 8px;" },
+                    h(
+                      component,
+                      {
+                        items: row.labels,
+                        maxLines: 2,
+                        style: `width:${width.value}px;max-width:100%;`,
+                      },
+                      {
+                        before: () => {
+                          beforeSlotCalls += 1;
+                          return h("span", { style: fixedBadgeStyle(72) }, "Lead");
+                        },
+                        item: ({ item }: { item: string }) => {
+                          itemSlotCalls += 1;
+                          return h("span", { style: fixedBadgeStyle(40) }, item);
+                        },
+                      },
+                    ),
+                  ),
+                ]),
+              ),
+            ),
+          ]),
+        );
+    },
+  });
+
+  const app = createApp(Host);
+  app.mount(container);
+
+  const mountedBenchmark = {
+    app,
+    container,
+    width,
+  };
+  mounted.add(mountedBenchmark);
+
+  return {
+    afterSlotCalls: () => afterSlotCalls,
+    beforeSlotCalls: () => beforeSlotCalls,
+    itemSlotCalls: () => itemSlotCalls,
+    mountedBenchmark,
+  };
+}
+
 async function runWidthSequence(
   mountedBenchmark: MountedBenchmark,
   widths: readonly number[],
@@ -440,6 +1536,49 @@ async function runWidthSequence(
 
   return {
     meanStepMs: totalMs / Math.max(1, measuredWidths.length),
+    rectReads: endRectTracking(),
+    totalMs,
+  };
+}
+
+async function runWidthBursts(
+  mountedBenchmark: MountedBenchmark,
+  bursts: readonly (readonly number[])[],
+  initialObservation: ScenarioObservation,
+): Promise<{
+  meanStepMs: number;
+  rectReads: number;
+  totalMs: number;
+}> {
+  const observations = [initialObservation];
+  let totalMs = 0;
+
+  beginRectTracking(mountedBenchmark.container);
+
+  for (const burst of bursts) {
+    const finalWidth = burst.at(-1);
+    if (finalWidth === undefined) {
+      throw new Error("Benchmark width bursts must not be empty.");
+    }
+
+    const stepStart = performance.now();
+    for (const width of burst) {
+      mountedBenchmark.width.value = width;
+      await nextTick();
+    }
+
+    const stableObservation = await waitForStableObservation(
+      mountedBenchmark.container,
+      finalWidth,
+      observations.at(-1)?.signature ?? null,
+      stepStart,
+    );
+    observations.push(stableObservation.observation);
+    totalMs += stableObservation.settledMs;
+  }
+
+  return {
+    meanStepMs: totalMs / Math.max(1, bursts.length),
     rectReads: endRectTracking(),
     totalMs,
   };
@@ -502,6 +1641,62 @@ async function runBenchmark(
   return summarize(runs);
 }
 
+async function runBurstScenario(
+  mountVariant: (component: Component) => MountedVariant,
+  initialWidth: number,
+  bursts: readonly (readonly number[])[],
+): Promise<BenchmarkRun> {
+  const mountedVariant = mountVariant(WrapClamp);
+  mountedVariant.mountedBenchmark.width.value = initialWidth;
+
+  try {
+    const initialObservation = (
+      await waitForStableObservation(
+        mountedVariant.mountedBenchmark.container,
+        initialWidth,
+        null,
+        performance.now(),
+      )
+    ).observation;
+    const baselineAfter = mountedVariant.afterSlotCalls();
+    const baselineBefore = mountedVariant.beforeSlotCalls();
+    const baselineItem = mountedVariant.itemSlotCalls();
+    const metrics = await runWidthBursts(
+      mountedVariant.mountedBenchmark,
+      bursts,
+      initialObservation,
+    );
+
+    return {
+      afterSlotCalls: mountedVariant.afterSlotCalls() - baselineAfter,
+      beforeSlotCalls: mountedVariant.beforeSlotCalls() - baselineBefore,
+      itemSlotCalls: mountedVariant.itemSlotCalls() - baselineItem,
+      meanStepMs: metrics.meanStepMs,
+      rectReads: metrics.rectReads,
+      totalMs: metrics.totalMs,
+    };
+  } finally {
+    destroyMountedBenchmark(mountedVariant.mountedBenchmark);
+  }
+}
+
+async function runBurstBenchmark(
+  mountVariant: (component: Component) => MountedVariant,
+  initialWidth: number,
+  bursts: readonly (readonly number[])[],
+): Promise<BenchmarkSummary> {
+  const runs: BenchmarkRun[] = [];
+
+  for (let runIndex = 0; runIndex < benchmarkWarmupRuns + benchmarkMeasuredRuns; runIndex += 1) {
+    const run = await runBurstScenario(mountVariant, initialWidth, bursts);
+    if (runIndex >= benchmarkWarmupRuns) {
+      runs.push(run);
+    }
+  }
+
+  return summarize(runs);
+}
+
 afterEach(() => {
   for (const mountedBenchmark of Array.from(mounted)) {
     destroyMountedBenchmark(mountedBenchmark);
@@ -548,11 +1743,124 @@ describe("WrapClamp benchmark", () => {
         scenario: "table-demo-width-sweep",
         summary: await runBenchmark(mountTableVariant, tableWidths),
       },
+      {
+        scenario: "table-demo-width-churn",
+        summary: await runBurstBenchmark(
+          mountTableVariant,
+          tableWidths[0] ?? 180,
+          tableWidthBursts,
+        ),
+      },
+      {
+        scenario: "no-affix-jump-grow",
+        summary: await runBenchmark(mountNoAffixJumpGrowVariant, noAffixJumpGrowWidths),
+      },
+      {
+        scenario: "no-affix-shrink",
+        summary: await runBenchmark(mountNoAffixJumpGrowVariant, noAffixShrinkWidths),
+      },
+      {
+        scenario: "no-affix-hidden-grow",
+        summary: await runBenchmark(mountNoAffixHiddenGrowVariant, noAffixHiddenGrowWidths),
+      },
+      {
+        scenario: "no-affix-large-n",
+        summary: await runBenchmark(mountNoAffixLargeNVariant, noAffixLargeNWidths),
+      },
+      {
+        scenario: "no-affix-narrow-item-grow",
+        summary: await runBenchmark(mountNoAffixNarrowItemGrowVariant, noAffixNarrowItemGrowWidths),
+      },
+      {
+        scenario: "no-affix-wide-item-grow",
+        summary: await runBenchmark(mountNoAffixWideItemGrowVariant, noAffixWideItemGrowWidths),
+      },
+      {
+        scenario: "no-affix-wide-container-grow",
+        summary: await runBenchmark(
+          mountNoAffixWideContainerGrowVariant,
+          noAffixWideContainerGrowWidths,
+        ),
+      },
+      {
+        scenario: "no-affix-tiny-item-wide-grow",
+        summary: await runBenchmark(
+          mountNoAffixTinyItemWideGrowVariant,
+          noAffixTinyItemWideGrowWidths,
+        ),
+      },
+      {
+        scenario: "no-affix-mixed-item-grow",
+        summary: await runBenchmark(mountNoAffixMixedItemGrowVariant, noAffixMixedItemGrowWidths),
+      },
+      {
+        scenario: "no-affix-heavy-item-grow",
+        summary: await runBenchmark(mountNoAffixHeavyItemGrowVariant, noAffixHeavyItemGrowWidths),
+      },
+      {
+        scenario: "before-affix-grow",
+        summary: await runBenchmark(mountBeforeAffixGrowVariant, beforeAffixGrowWidths),
+      },
+      {
+        scenario: "before-affix-shrink",
+        summary: await runBenchmark(mountBeforeAffixShrinkVariant, beforeAffixShrinkWidths),
+      },
+      {
+        scenario: "dynamic-before-grow",
+        summary: await runBenchmark(mountDynamicBeforeGrowVariant, dynamicBeforeGrowWidths),
+      },
+      {
+        scenario: "dynamic-before-shrink",
+        summary: await runBenchmark(mountDynamicBeforeShrinkVariant, dynamicBeforeShrinkWidths),
+      },
+      {
+        scenario: "static-after-grow",
+        summary: await runBenchmark(mountStaticAfterGrowVariant, staticAfterGrowWidths),
+      },
+      {
+        scenario: "static-after-shrink",
+        summary: await runBenchmark(mountStaticAfterShrinkVariant, staticAfterShrinkWidths),
+      },
+      {
+        scenario: "static-before-dynamic-after-grow",
+        summary: await runBenchmark(
+          mountStaticBeforeDynamicAfterGrowVariant,
+          staticBeforeDynamicAfterGrowWidths,
+        ),
+      },
+      {
+        scenario: "after-affix-shrink",
+        summary: await runBenchmark(mountAfterAffixShrinkVariant, afterAffixShrinkWidths),
+      },
+      {
+        scenario: "max-height-grow",
+        summary: await runBenchmark(mountMaxHeightGrowVariant, maxHeightGrowWidths),
+      },
+      {
+        scenario: "max-height-shrink",
+        summary: await runBenchmark(mountMaxHeightShrinkVariant, maxHeightShrinkWidths),
+      },
+      {
+        scenario: "before-max-height-grow",
+        summary: await runBenchmark(mountBeforeMaxHeightGrowVariant, beforeMaxHeightGrowWidths),
+      },
+      {
+        scenario: "before-max-height-shrink",
+        summary: await runBenchmark(mountBeforeMaxHeightShrinkVariant, beforeMaxHeightShrinkWidths),
+      },
+      {
+        scenario: "mixed-lines-height-grow",
+        summary: await runBenchmark(mountMixedLimitGrowVariant, mixedLimitGrowWidths),
+      },
+      {
+        scenario: "mixed-lines-height-shrink",
+        summary: await runBenchmark(mountMixedLimitShrinkVariant, mixedLimitShrinkWidths),
+      },
     ];
 
     console.error(`WRAP_BENCHMARK ${JSON.stringify({ scenarios })}`);
 
-    expect(scenarios).toHaveLength(2);
+    expect(scenarios).toHaveLength(27);
     for (const scenario of scenarios) {
       expect(scenario.summary.runs).toHaveLength(benchmarkMeasuredRuns);
     }

--- a/packages/vue-clamp/tests/wrap.browser.benchmark.ts
+++ b/packages/vue-clamp/tests/wrap.browser.benchmark.ts
@@ -451,7 +451,7 @@ function mountTableVariant(component: Component): MountedVariant {
   };
 }
 
-function mountNoAffixJumpGrowVariant(component: Component): MountedVariant {
+function mountNoAffixResizeVariant(component: Component): MountedVariant {
   const width = ref(noAffixJumpGrowWidths[0] ?? 340);
   const container = document.createElement("div");
   document.body.append(container);
@@ -1753,11 +1753,11 @@ describe("WrapClamp benchmark", () => {
       },
       {
         scenario: "no-affix-jump-grow",
-        summary: await runBenchmark(mountNoAffixJumpGrowVariant, noAffixJumpGrowWidths),
+        summary: await runBenchmark(mountNoAffixResizeVariant, noAffixJumpGrowWidths),
       },
       {
         scenario: "no-affix-shrink",
-        summary: await runBenchmark(mountNoAffixJumpGrowVariant, noAffixShrinkWidths),
+        summary: await runBenchmark(mountNoAffixResizeVariant, noAffixShrinkWidths),
       },
       {
         scenario: "no-affix-hidden-grow",

--- a/packages/vue-clamp/tests/wrap.browser.test.ts
+++ b/packages/vue-clamp/tests/wrap.browser.test.ts
@@ -25,6 +25,7 @@ type MountWrapOptions = {
   before?: (props: WrapClampSlotProps<string>) => VNodeChild;
   after?: (props: WrapClampSlotProps<string>) => VNodeChild;
 };
+type MixedHeightAlignment = "baseline" | "center" | "flex-end";
 
 const mounted = new Set<MountedWrapClamp>();
 
@@ -64,6 +65,32 @@ function fixedBadgeStyle(width: number): string {
     "margin-inline-end:6px",
     "margin-block-end:6px",
     "white-space:nowrap",
+  ].join(";");
+}
+
+function mixedHeightAlignmentItemStyle(alignment: MixedHeightAlignment, index: number): string {
+  const common = [
+    "width:64px",
+    "border:1px solid currentColor",
+    "box-sizing:border-box",
+    "white-space:nowrap",
+  ];
+
+  if (alignment === "baseline") {
+    return [
+      "display:inline-block",
+      ...common,
+      `font-size:${index === 0 ? 30 : 12}px`,
+      `line-height:${index === 0 ? 34 : 14}px`,
+    ].join(";");
+  }
+
+  return [
+    "display:inline-flex",
+    `align-items:${alignment}`,
+    "justify-content:center",
+    ...common,
+    `height:${index === 0 ? 44 : 18}px`,
   ].join(";");
 }
 
@@ -163,7 +190,9 @@ function wrapSnapshot(root: HTMLElement): { after: string | null; items: string[
 }
 
 function wrapLineCount(root: HTMLElement): number {
-  const tops: number[] = [];
+  let lineCount = 0;
+  let lineTop = 0;
+  let lineBottom = 0;
 
   for (const child of wrapContent(root).children) {
     if (!(child instanceof HTMLElement)) {
@@ -180,12 +209,49 @@ function wrapLineCount(root: HTMLElement): number {
       continue;
     }
 
-    if (!tops.some((top) => Math.abs(top - rect.top) <= 0.5)) {
-      tops.push(rect.top);
+    if (lineCount === 0) {
+      lineCount = 1;
+      lineTop = rect.top;
+      lineBottom = rect.bottom;
+    } else {
+      const verticalOverlap = Math.min(rect.bottom, lineBottom) - Math.max(rect.top, lineTop);
+      const smallerHeight = Math.min(rect.height, lineBottom - lineTop);
+
+      if (verticalOverlap <= Math.min(0.5, smallerHeight / 2)) {
+        lineCount += 1;
+        lineTop = rect.top;
+        lineBottom = rect.bottom;
+      } else {
+        lineTop = Math.min(lineTop, rect.top);
+        lineBottom = Math.max(lineBottom, rect.bottom);
+      }
     }
   }
 
-  return tops.length;
+  return lineCount;
+}
+
+function expectVisibleAtomicBoxesWithinRoot(root: HTMLElement): void {
+  const rootRect = root.getBoundingClientRect();
+  const visibleBottom = rootRect.top + root.clientTop + root.clientHeight;
+
+  for (const child of wrapContent(root).children) {
+    if (!(child instanceof HTMLElement)) {
+      continue;
+    }
+
+    const part = child.dataset.part;
+    if (part !== "before" && part !== "item" && part !== "after") {
+      continue;
+    }
+
+    const rect = child.getBoundingClientRect();
+    if (rect.width <= 0 || rect.height <= 0) {
+      continue;
+    }
+
+    expect(rect.bottom).toBeLessThanOrEqual(visibleBottom + 0.5);
+  }
 }
 
 afterEach(() => {
@@ -274,6 +340,256 @@ describe("WrapClamp browser contract", () => {
     );
   });
 
+  it("restores a no-affix multiline prefix after a width jump", async () => {
+    const items = ["One", "Two", "Three", "Four", "Five", "Six", "Seven"];
+    const mountedClamp = mountWrapClamp({
+      items,
+      props: {
+        maxLines: 2,
+      },
+      width: 340,
+      item: ({ item }) => h("span", { style: fixedBadgeStyle(68) }, item),
+    });
+
+    await settle(5);
+
+    expect(wrapSnapshot(rootElement(mountedClamp.container))).toEqual({
+      after: null,
+      items,
+    });
+
+    mountedClamp.width.value = 150;
+    await settle(6);
+
+    const shrunkSnapshot = wrapSnapshot(rootElement(mountedClamp.container));
+    expect(shrunkSnapshot.after).toBeNull();
+    expect(shrunkSnapshot.items.length).toBeLessThan(items.length);
+    expect(shrunkSnapshot.items).toEqual(items.slice(0, shrunkSnapshot.items.length));
+
+    mountedClamp.width.value = 340;
+    await settle(6);
+
+    expect(wrapSnapshot(rootElement(mountedClamp.container))).toEqual({
+      after: null,
+      items,
+    });
+  });
+
+  it("does not leave materialized no-affix probe items after hidden grow", async () => {
+    const items = Array.from({ length: 24 }, (_, index) => `I${index + 1}`);
+    const mountedClamp = mountWrapClamp({
+      items,
+      props: {
+        maxLines: 2,
+      },
+      width: 120,
+      item: ({ item }) => h("span", { style: fixedBadgeStyle(40) }, item),
+    });
+
+    await settle(5);
+
+    const initialVisibleCount = wrapItems(rootElement(mountedClamp.container)).length;
+    expect(initialVisibleCount).toBeLessThan(items.length);
+
+    mountedClamp.width.value = 520;
+    await settle(8);
+
+    const root = rootElement(mountedClamp.container);
+    const visibleItems = wrapItems(root);
+    expect(visibleItems.length).toBeGreaterThan(initialVisibleCount);
+    expect(visibleItems.map((item) => item.textContent?.trim())).toEqual(
+      items.slice(0, visibleItems.length),
+    );
+    expect(root.querySelector('[data-part="item"][aria-hidden="true"]')).toBeNull();
+  });
+
+  it("restores a wide no-affix grow frontier above the old fixed budget", async () => {
+    const items = Array.from({ length: 120 }, (_, index) => `I${index + 1}`);
+    const mountedClamp = mountWrapClamp({
+      items,
+      props: {
+        maxLines: 2,
+      },
+      width: 120,
+      item: ({ item }) => h("span", { style: fixedBadgeStyle(16) }, item),
+    });
+
+    await settle(5);
+
+    const initialVisibleCount = wrapItems(rootElement(mountedClamp.container)).length;
+    expect(initialVisibleCount).toBeLessThan(32);
+
+    mountedClamp.width.value = 960;
+    await settle(8);
+
+    const root = rootElement(mountedClamp.container);
+    const visibleItems = wrapItems(root);
+    expect(visibleItems.length).toBeGreaterThan(32);
+    expect(visibleItems.map((item) => item.textContent?.trim())).toEqual(
+      items.slice(0, visibleItems.length),
+    );
+    expect(root.querySelector('[data-part="item"][aria-hidden="true"]')).toBeNull();
+  });
+
+  it("continues settling after fallback-budget materialized grow starts without measured widths", async () => {
+    const initialItems = Array.from({ length: 60 }, (_, index) => `Wide${index + 1}`);
+    const nextItems = Array.from({ length: 60 }, (_, index) => `N${index + 1}`);
+    const mountedClamp = mountWrapClamp({
+      items: initialItems,
+      props: {
+        maxLines: 2,
+      },
+      width: 120,
+      item: ({ item }) =>
+        h("span", { style: fixedBadgeStyle(item.startsWith("Wide") ? 96 : 16) }, item),
+    });
+
+    await settle(5);
+
+    const initialVisibleCount = wrapItems(rootElement(mountedClamp.container)).length;
+    expect(initialVisibleCount).toBeGreaterThan(0);
+    expect(initialVisibleCount).toBeLessThan(32);
+
+    mountedClamp.items.value = nextItems;
+    mountedClamp.width.value = 520;
+    await settle(12);
+
+    const root = rootElement(mountedClamp.container);
+    const visibleItems = wrapItems(root);
+    expect(visibleItems.length).toBeGreaterThan(32);
+    expect(visibleItems.map((item) => item.textContent?.trim())).toEqual(
+      nextItems.slice(0, visibleItems.length),
+    );
+    expect(wrapLineCount(root)).toBeLessThanOrEqual(2);
+    expect(root.querySelector('[data-part="item"][aria-hidden="true"]')).toBeNull();
+  });
+
+  it("restores a before-only grow frontier when the before geometry is stable", async () => {
+    const items = Array.from({ length: 24 }, (_, index) => `I${index + 1}`);
+    const mountedClamp = mountWrapClamp({
+      items,
+      props: {
+        maxLines: 2,
+      },
+      width: 120,
+      before: () => h("span", { style: fixedBadgeStyle(72) }, "Lead"),
+      item: ({ item }) => h("span", { style: fixedBadgeStyle(40) }, item),
+    });
+
+    await settle(5);
+
+    const initialVisibleCount = wrapItems(rootElement(mountedClamp.container)).length;
+    expect(initialVisibleCount).toBeLessThan(items.length);
+
+    mountedClamp.width.value = 520;
+    await settle(8);
+
+    const root = rootElement(mountedClamp.container);
+    const visibleItems = wrapItems(root);
+    expect(wrapBefore(root)?.textContent?.trim()).toBe("Lead");
+    expect(visibleItems.length).toBeGreaterThan(initialVisibleCount);
+    expect(visibleItems.map((item) => item.textContent?.trim())).toEqual(
+      items.slice(0, visibleItems.length),
+    );
+    expect(root.querySelector('[data-part="item"][aria-hidden="true"]')).toBeNull();
+  });
+
+  it("falls back when a before slot changes geometry after grow", async () => {
+    const items = Array.from({ length: 20 }, (_, index) => `I${index + 1}`);
+    const mountedClamp = mountWrapClamp({
+      items,
+      props: {
+        maxLines: 2,
+      },
+      width: 120,
+      before: ({ hiddenItems }) =>
+        h("span", { style: fixedBadgeStyle(hiddenItems.length >= 10 ? 160 : 40) }, "Lead"),
+      item: ({ item }) => h("span", { style: fixedBadgeStyle(40) }, item),
+    });
+
+    await settle(5);
+
+    mountedClamp.width.value = 520;
+    await settle(10);
+
+    const root = rootElement(mountedClamp.container);
+    const visibleItems = wrapItems(root);
+    const hiddenCount = items.length - visibleItems.length;
+    expect(hiddenCount).toBeGreaterThanOrEqual(0);
+    expect(hiddenCount).toBeLessThan(10);
+    expect(visibleItems.map((item) => item.textContent?.trim())).toEqual(
+      items.slice(0, visibleItems.length),
+    );
+    expect(wrapLineCount(root)).toBeLessThanOrEqual(2);
+    expect(root.querySelector('[data-part="item"][aria-hidden="true"]')).toBeNull();
+  });
+
+  it("jumps from a static before and dynamic after hint back to a verified live-DOM result", async () => {
+    const items = Array.from({ length: 24 }, (_, index) => `I${index + 1}`);
+    const mountedClamp = mountWrapClamp({
+      items,
+      props: {
+        maxLines: 2,
+      },
+      width: 120,
+      before: () => h("span", { style: fixedBadgeStyle(72) }, "Lead"),
+      item: ({ item }) => h("span", { style: fixedBadgeStyle(40) }, item),
+      after: ({ clamped, hiddenItems }) =>
+        clamped
+          ? h(
+              "span",
+              { style: fixedBadgeStyle(hiddenItems.length >= 10 ? 68 : 32) },
+              `+${hiddenItems.length}`,
+            )
+          : null,
+    });
+
+    await settle(5);
+
+    const initialVisibleCount = wrapItems(rootElement(mountedClamp.container)).length;
+    expect(initialVisibleCount).toBeLessThan(items.length);
+
+    mountedClamp.width.value = 520;
+    await settle(10);
+
+    const root = rootElement(mountedClamp.container);
+    const grownSnapshot = wrapSnapshot(root);
+    const hiddenCount = items.length - grownSnapshot.items.length;
+    expect(grownSnapshot.items.length).toBeGreaterThan(initialVisibleCount);
+    expect(grownSnapshot.items).toEqual(items.slice(0, grownSnapshot.items.length));
+    expect(grownSnapshot.after).toBe(hiddenCount > 0 ? `+${hiddenCount}` : null);
+    expect(wrapBefore(root)?.textContent?.trim()).toBe("Lead");
+    expect(wrapLineCount(root)).toBeLessThanOrEqual(2);
+    expect(root.querySelector('[data-part="item"][aria-hidden="true"]')).toBeNull();
+  });
+
+  it("falls back when a before slot changes geometry after shrink", async () => {
+    const items = Array.from({ length: 20 }, (_, index) => `I${index + 1}`);
+    const mountedClamp = mountWrapClamp({
+      items,
+      props: {
+        maxLines: 2,
+      },
+      width: 520,
+      before: ({ hiddenItems }) =>
+        h("span", { style: fixedBadgeStyle(hiddenItems.length >= 10 ? 160 : 40) }, "Lead"),
+      item: ({ item }) => h("span", { style: fixedBadgeStyle(40) }, item),
+    });
+
+    await settle(5);
+
+    mountedClamp.width.value = 120;
+    await settle(10);
+
+    const root = rootElement(mountedClamp.container);
+    const visibleItems = wrapItems(root);
+    expect(visibleItems.map((item) => item.textContent?.trim())).toEqual(
+      items.slice(0, visibleItems.length),
+    );
+    expect(wrapLineCount(root)).toBeLessThanOrEqual(2);
+    expect(root.querySelector('[data-part="item"][aria-hidden="true"]')).toBeNull();
+  });
+
   it("uses the one-line calculation path when the after width depends on hiddenItems length", async () => {
     const mountedClamp = mountWrapClamp({
       items: ["Alpha", "Beta", "Gamma"],
@@ -341,6 +657,41 @@ describe("WrapClamp browser contract", () => {
     expect(hiddenCount).toBeLessThan(10);
     expect(grownSnapshot.after).toBe(`+${hiddenCount}`);
     expect(grownSnapshot.items).toEqual(items.slice(0, grownSnapshot.items.length));
+    expect(wrapLineCount(root)).toBeLessThanOrEqual(1);
+  });
+
+  it("settles across a hiddenItems digit boundary when shrink changes after width", async () => {
+    const items = Array.from({ length: 20 }, (_, index) => `I${index + 1}`);
+    const mountedClamp = mountWrapClamp({
+      items,
+      props: {
+        maxLines: 1,
+      },
+      width: 420,
+      item: ({ item }) => h("span", { style: fixedBadgeStyle(20) }, item),
+      after: ({ clamped, hiddenItems }) =>
+        clamped
+          ? h(
+              "span",
+              { style: fixedBadgeStyle(hiddenItems.length >= 10 ? 64 : 32) },
+              `+${hiddenItems.length}`,
+            )
+          : null,
+    });
+
+    await settle(8);
+
+    const initialSnapshot = wrapSnapshot(rootElement(mountedClamp.container));
+    expect(items.length - initialSnapshot.items.length).toBeLessThan(10);
+
+    mountedClamp.width.value = 324;
+    await settle(8);
+
+    const root = rootElement(mountedClamp.container);
+    expect(wrapSnapshot(root)).toEqual({
+      after: "+11",
+      items: items.slice(0, 9),
+    });
     expect(wrapLineCount(root)).toBeLessThanOrEqual(1);
   });
 
@@ -460,6 +811,214 @@ describe("WrapClamp browser contract", () => {
     expect(root.clientHeight).toBeLessThanOrEqual(30);
     expect(wrapItems(root).length).toBeLessThan(5);
     expect(wrapAfter(root)?.textContent).not.toBeNull();
+  });
+
+  it("shrinks a no-after maxHeight clamp from the current visible prefix", async () => {
+    const items = Array.from({ length: 24 }, (_, index) => `I${index + 1}`);
+    const mountedClamp = mountWrapClamp({
+      items,
+      props: {
+        maxHeight: "60px",
+      },
+      width: 520,
+      item: ({ item }) => h("span", { style: fixedBadgeStyle(40) }, item),
+    });
+
+    await settle(5);
+
+    const initialCount = wrapItems(rootElement(mountedClamp.container)).length;
+    expect(initialCount).toBeGreaterThan(0);
+
+    mountedClamp.width.value = 120;
+    await settle(8);
+
+    const root = rootElement(mountedClamp.container);
+    const visibleItems = wrapItems(root);
+    expect(root.clientHeight).toBeLessThanOrEqual(60);
+    expect(visibleItems.length).toBeLessThan(initialCount);
+    expect(visibleItems.map((item) => item.textContent?.trim())).toEqual(
+      items.slice(0, visibleItems.length),
+    );
+    expect(root.querySelector('[data-part="item"][aria-hidden="true"]')).toBeNull();
+  });
+
+  it("grows a no-after maxHeight clamp without leaving materialized probe items", async () => {
+    const items = Array.from({ length: 24 }, (_, index) => `I${index + 1}`);
+    const mountedClamp = mountWrapClamp({
+      items,
+      props: {
+        maxHeight: "60px",
+      },
+      width: 120,
+      item: ({ item }) => h("span", { style: fixedBadgeStyle(40) }, item),
+    });
+
+    await settle(5);
+
+    const initialCount = wrapItems(rootElement(mountedClamp.container)).length;
+    expect(initialCount).toBeGreaterThan(0);
+    expect(initialCount).toBeLessThan(items.length);
+
+    mountedClamp.width.value = 520;
+    await settle(8);
+
+    const root = rootElement(mountedClamp.container);
+    const visibleItems = wrapItems(root);
+    expect(root.clientHeight).toBeLessThanOrEqual(60);
+    expect(visibleItems.length).toBeGreaterThan(initialCount);
+    expect(visibleItems.map((item) => item.textContent?.trim())).toEqual(
+      items.slice(0, visibleItems.length),
+    );
+    expectVisibleAtomicBoxesWithinRoot(root);
+    expect(root.querySelector('[data-part="item"][aria-hidden="true"]')).toBeNull();
+  });
+
+  it("clamps wrapped items when content has CSS gap", async () => {
+    const style = document.createElement("style");
+    style.textContent = `
+      [data-wrap-gap] [data-part="content"] {
+        column-gap: 8px;
+        row-gap: 6px;
+      }
+    `;
+    document.head.append(style);
+
+    try {
+      const items = Array.from({ length: 24 }, (_, index) => `I${index + 1}`);
+      const mountedClamp = mountWrapClamp({
+        items,
+        props: {
+          "data-wrap-gap": "",
+          maxLines: 2,
+        },
+        width: 120,
+        item: ({ item }) => h("span", { style: fixedBadgeStyle(40) }, item),
+      });
+
+      await settle(5);
+
+      const initialCount = wrapItems(rootElement(mountedClamp.container)).length;
+      expect(initialCount).toBeGreaterThan(0);
+      expect(wrapLineCount(rootElement(mountedClamp.container))).toBeLessThanOrEqual(2);
+
+      mountedClamp.width.value = 520;
+      await settle(8);
+
+      const root = rootElement(mountedClamp.container);
+      const visibleItems = wrapItems(root);
+      expect(visibleItems.length).toBeGreaterThan(initialCount);
+      expect(wrapLineCount(root)).toBeLessThanOrEqual(2);
+      expect(visibleItems.map((item) => item.textContent?.trim())).toEqual(
+        items.slice(0, visibleItems.length),
+      );
+      expect(root.querySelector('[data-part="item"][aria-hidden="true"]')).toBeNull();
+    } finally {
+      style.remove();
+    }
+  });
+
+  it("keeps aligned mixed-height items on the same wrap line", async () => {
+    const style = document.createElement("style");
+    style.textContent = `
+      [data-wrap-align] [data-part="content"] {
+        gap: 0;
+      }
+      [data-wrap-align="center"] [data-part="content"] { align-items: center; }
+      [data-wrap-align="flex-end"] [data-part="content"] { align-items: flex-end; }
+      [data-wrap-align="baseline"] [data-part="content"] { align-items: baseline; }
+    `;
+    document.head.append(style);
+
+    try {
+      const cases: Array<{ alignment: MixedHeightAlignment; items: readonly string[] }> = [
+        {
+          alignment: "center",
+          items: ["Tall", "Short", "Next"],
+        },
+        {
+          alignment: "flex-end",
+          items: ["Tall", "Short", "Next"],
+        },
+        {
+          alignment: "baseline",
+          items: ["Large", "Small", "Next"],
+        },
+      ];
+
+      for (const { alignment, items } of cases) {
+        const mountedClamp = mountWrapClamp({
+          items,
+          props: {
+            "data-wrap-align": alignment,
+            maxLines: 1,
+          },
+          width: 150,
+          item: ({ index, item }) =>
+            h("span", { style: mixedHeightAlignmentItemStyle(alignment, index) }, item),
+        });
+
+        await settle(6);
+
+        const root = rootElement(mountedClamp.container);
+        const visibleItems = wrapItems(root);
+        expect(visibleItems.map((item) => item.textContent?.trim())).toEqual(items.slice(0, 2));
+        expect(wrapLineCount(root)).toBe(1);
+
+        const [first, second] = visibleItems;
+        if (!first || !second) {
+          throw new Error(`Expected two visible ${alignment} mixed-height items.`);
+        }
+        expect(
+          Math.abs(first.getBoundingClientRect().top - second.getBoundingClientRect().top),
+        ).toBeGreaterThan(0.5);
+      }
+    } finally {
+      style.remove();
+    }
+  });
+
+  it("settles when item slot widths change without replacing the item array", async () => {
+    const wide = ref(false);
+    const items = Array.from({ length: 16 }, (_, index) => `I${index + 1}`);
+    const mountedClamp = mountWrapClamp({
+      items,
+      props: {
+        maxLines: 2,
+      },
+      width: 260,
+      item: ({ item }) => h("span", { style: fixedBadgeStyle(wide.value ? 72 : 32) }, item),
+    });
+
+    await settle(6);
+
+    const initialRoot = rootElement(mountedClamp.container);
+    const initialCount = wrapItems(initialRoot).length;
+    expect(initialCount).toBeGreaterThan(0);
+    expect(wrapLineCount(initialRoot)).toBeLessThanOrEqual(2);
+
+    wide.value = true;
+    await settle(10);
+
+    const widerRoot = rootElement(mountedClamp.container);
+    const widerItems = wrapItems(widerRoot);
+    expect(widerItems.length).toBeLessThan(initialCount);
+    expect(wrapLineCount(widerRoot)).toBeLessThanOrEqual(2);
+    expect(widerItems.map((item) => item.textContent?.trim())).toEqual(
+      items.slice(0, widerItems.length),
+    );
+    expect(widerRoot.querySelector('[data-part="item"][aria-hidden="true"]')).toBeNull();
+
+    wide.value = false;
+    await settle(10);
+
+    const narrowRoot = rootElement(mountedClamp.container);
+    const narrowItems = wrapItems(narrowRoot);
+    expect(narrowItems.length).toBeGreaterThan(widerItems.length);
+    expect(wrapLineCount(narrowRoot)).toBeLessThanOrEqual(2);
+    expect(narrowItems.map((item) => item.textContent?.trim())).toEqual(
+      items.slice(0, narrowItems.length),
+    );
+    expect(narrowRoot.querySelector('[data-part="item"][aria-hidden="true"]')).toBeNull();
   });
 
   it("keeps the after slot at logical inline-end in RTL mode", async () => {

--- a/vite.browser.config.ts
+++ b/vite.browser.config.ts
@@ -1,5 +1,6 @@
 import vue from "@vitejs/plugin-vue";
 import { playwright } from "vite-plus/test/browser-playwright";
+import { websiteCodeHighlightPlugin } from "./packages/website/vite.highlight.ts";
 import { websitePublicDir, websiteResolve } from "./packages/website/vite.shared.ts";
 
 export default {
@@ -9,7 +10,7 @@ export default {
     __VUE_PROD_HYDRATION_MISMATCH_DETAILS__: false,
   },
   publicDir: websitePublicDir,
-  plugins: [vue()],
+  plugins: [websiteCodeHighlightPlugin(), vue()],
   resolve: websiteResolve,
   test: {
     include: ["packages/vue-clamp/tests/**/*.browser.test.ts"],


### PR DESCRIPTION
## Summary

- Optimizes WrapClamp resize settlement with verified static-flow hints, bounded materialized grow search, and a guarded dynamic-after jump hint.
- Keeps the public API and DOM parts unchanged.
- Adds regression coverage for materialized grow fallback, mixed row detection, maxHeight/static-flow cases, and benchmark guards.

## Performance Snapshot

Median browser-settled time in representative resize scenarios. Lower is better.

![WrapClamp benchmark chart](https://raw.githubusercontent.com/Justineo/vue-clamp/d35b1a8719e9e4b8f4eb3484bdc7e31f0b2e9762/journey/research/308-wrapclamp-performance-chart.svg)

| Scenario | Before | After | Change |
| --- | ---: | ---: | ---: |
| Static before + dynamic after grow | ~500ms | 196ms | -61% |
| No-affix tiny-item wide grow | ~387ms | 158ms | -59% |
| Before-affix grow | ~436ms | 190ms | -56% |
| maxHeight grow | ~208ms | 132ms | -37% |
| Table width churn | ~215ms | 165ms | -23% |

The largest covered cases reduce item slot calls by roughly 45-84% and layout rect reads by roughly 21-75%.

## Validation

- `vp check`
- `vp test`
- `vp run test:browser`
- `vp test -c vite.browser.benchmark.config.ts packages/vue-clamp/tests/wrap.browser.benchmark.ts`

Browser runs still print the known non-fatal ResizeObserver loop notification.
