### PR TITLE
fix: create text segmenters lazily

### DIFF
--- a/packages/vue-clamp/src/text.ts
+++ b/packages/vue-clamp/src/text.ts
@@ -13,13 +13,27 @@ import type { ClampBoundary, ClampLength, LineClampLocation } from "./types.ts";
 
 // Text preparation is separated from DOM measurement so width-only reclamps can
 // reuse the same boundary list instead of segmenting the source text again.
-const graphemeSegmenter = new Intl.Segmenter(undefined, {
-  granularity: "grapheme",
-});
+// Segmenters are built on first use: module evaluation then stays side effect free,
+// so bundlers can drop this module for consumers that only import layout clamping,
+// and ASCII-only content never constructs one.
+let graphemeSegmenter: Intl.Segmenter | undefined;
+let wordSegmenter: Intl.Segmenter | undefined;
 
-const wordSegmenter = new Intl.Segmenter(undefined, {
-  granularity: "word",
-});
+function segmentGraphemes(text: string): Intl.Segments {
+  graphemeSegmenter ??= new Intl.Segmenter(undefined, {
+    granularity: "grapheme",
+  });
+
+  return graphemeSegmenter.segment(text);
+}
+
+function segmentWords(text: string): Intl.Segments {
+  wordSegmenter ??= new Intl.Segmenter(undefined, {
+    granularity: "word",
+  });
+
+  return wordSegmenter.segment(text);
+}
 
 export interface PreparedText {
   readonly text: string;
@@ -145,7 +159,7 @@ function graphemeBoundaryOffsets(text: string): number[] {
   const boundaryOffsets = [0];
   let offset = 0;
 
-  for (const part of graphemeSegmenter.segment(text)) {
+  for (const part of segmentGraphemes(text)) {
     offset += part.segment.length;
     boundaryOffsets.push(offset);
   }
@@ -161,7 +175,7 @@ function wordBoundaryOffsets(
   const boundaryOffsets = [0];
   let fallbackIndex = 0;
 
-  for (const part of wordSegmenter.segment(text)) {
+  for (const part of segmentWords(text)) {
     const offset = part.index + part.segment.length;
     while (!asciiSafe && (fallbackBoundaryOffsets[fallbackIndex] ?? Infinity) < offset) {
       fallbackIndex += 1;

--- a/packages/vue-clamp/tests/exports.test.ts
+++ b/packages/vue-clamp/tests/exports.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from "vite-plus/test";
+import { describe, expect, it, vi } from "vite-plus/test";
 import * as exports from "../src/index.ts";
 
 describe("Public exports", () => {
@@ -17,5 +17,30 @@ describe("Public exports", () => {
     expect("borderBoxWidth" in exports).toBe(false);
     expect("clampTextToFit" in exports).toBe(false);
     expect("prepareRich" in exports).toBe(false);
+  });
+});
+
+describe("Module evaluation", () => {
+  it("does not construct a segmenter while loading the package", async () => {
+    const construct = vi.fn();
+    const NativeSegmenter = Intl.Segmenter;
+
+    class TrackedSegmenter extends NativeSegmenter {
+      constructor(...args: ConstructorParameters<typeof NativeSegmenter>) {
+        construct();
+        super(...args);
+      }
+    }
+
+    Object.defineProperty(Intl, "Segmenter", { configurable: true, value: TrackedSegmenter });
+    vi.resetModules();
+
+    try {
+      await import("../src/index.ts");
+      expect(construct).not.toHaveBeenCalled();
+    } finally {
+      Object.defineProperty(Intl, "Segmenter", { configurable: true, value: NativeSegmenter });
+      vi.resetModules();
+    }
   });
 });


### PR DESCRIPTION
Fixes #126.

`src/text.ts` constructed both `Intl.Segmenter` instances at module evaluation, which made the module side-effectful:

- rolldown keeps the unused constructions in consumer bundles that only import `WrapClamp` (rollup drops them — it knows `Intl.Segmenter` construction is pure);
- on engines without `Intl.Segmenter` (Firefox < 125, Chrome < 87, Safari < 14.1) the chunk throws while evaluating, before any clamp runs.

### Change

- Construct each segmenter on first use and reuse it afterwards; module evaluation stays pure.
- No behavior change: the same instances are shared across calls, and ASCII-only content never constructs one because `asciiBoundaryOffsets` returns first.
- Regression test: importing the package constructs no segmenter.

Verified in a Vite 8 app importing only `WrapClamp`: `text.ts` is tree-shaken out of the built chunk, and the page renders on an engine without `Intl.Segmenter`.
